### PR TITLE
Import/export of irreductible representation associated to YoungTableau

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "vendor/googletest"]
 	path = vendor/googletest
 	url = git@github.com:google/googletest.git
+[submodule "vendor/constexpr-to-string"]
+	path = vendor/constexpr-to-string
+	url = git@github.com:tcsullivan/constexpr-to-string.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,3 @@
 [submodule "vendor/googletest"]
 	path = vendor/googletest
 	url = git@github.com:google/googletest.git
-[submodule "vendor/constexpr-to-string"]
-	path = vendor/constexpr-to-string
-	url = git@github.com:tcsullivan/constexpr-to-string.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ project(SimiLie C CXX)
 
 set_property(GLOBAL PROPERTY GLOBAL_DEPENDS_NO_CYCLES ON)
 
-set(CMAKE_CXX_STANDARD 20 CACHE INTERNAL "The C++ standard whose features are requested to build this project.")
+set(CMAKE_CXX_STANDARD 23 CACHE INTERNAL "The C++ standard whose features are requested to build this project.")
 
 # Set default DDC options when included
 option(DDC_BUILD_BENCHMARKS       "Build DDC benchmarks." OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,12 @@ option(DDC_BUILD_DOCUMENTATION    "Build DDC documentation/website" OFF)
 option(DDC_BUILD_EXAMPLES         "Build DDC examples" OFF)
 option(DDC_BUILD_TESTS            "Build DDC tests if BUILD_TESTING is enabled" OFF)
 
+# Custom variables
+if(NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/irreps_dict.bin)
+    file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/irreps_dict.bin "")
+endif()
+add_compile_definitions("IRREPS_DICT_PATH=\"${CMAKE_CURRENT_BINARY_DIR}/irreps_dict.bin\"")
+
 # Our dependencies
 
 ## Use CTest for running tests

--- a/src/csr/csr.hpp
+++ b/src/csr/csr.hpp
@@ -7,35 +7,47 @@
 
 #include <ddc/ddc.hpp>
 
+#include "csr_dynamic.hpp"
 #include "tensor_impl.hpp"
 
 namespace sil {
 
 namespace csr {
 
+namespace detail {
+
+template <class Ids>
+struct ArrayOfVectorsToArrayOfArrays;
+
+template <std::size_t... I>
+struct ArrayOfVectorsToArrayOfArrays<std::index_sequence<I...>>
+{
+    template <std::size_t N>
+    static void run(
+            std::array<std::array<std::size_t, N>, sizeof...(I)>& arr,
+            std::array<std::vector<std::size_t>, sizeof...(I)> const& vec)
+    {
+        (std::copy_n(vec[I].begin(), N, arr[I].begin()), ...);
+    }
+};
+
+} // namespace detail
+
 // Only natural indexing supported
-template <class HeadTensorIndex, class... TailTensorIndex>
+template <std::size_t N, class HeadTensorIndex, class... TailTensorIndex>
 class Csr
 {
 private:
     ddc::DiscreteDomain<HeadTensorIndex, TailTensorIndex...> m_domain;
-    std::vector<std::size_t> m_coalesc_idx;
-    std::array<std::vector<std::size_t>, sizeof...(TailTensorIndex)> m_idx;
-    std::vector<double> m_values;
+    std::array<std::size_t, HeadTensorIndex::size() + 1> m_coalesc_idx;
+    std::array<std::array<std::size_t, N>, sizeof...(TailTensorIndex)> m_idx;
+    std::array<double, N> m_values;
 
 public:
-    Csr(ddc::DiscreteDomain<HeadTensorIndex, TailTensorIndex...> domain)
-        : m_domain(domain)
-        , m_coalesc_idx({0})
-        , m_idx()
-        , m_values()
-    {
-    }
-
     Csr(ddc::DiscreteDomain<HeadTensorIndex, TailTensorIndex...> domain,
-        std::vector<std::size_t> coalesc_idx,
-        std::array<std::vector<std::size_t>, sizeof...(TailTensorIndex)> idx,
-        std::vector<double> values)
+        std::array<std::size_t, HeadTensorIndex::size() + 1> coalesc_idx,
+        std::array<std::array<std::size_t, N>, sizeof...(TailTensorIndex)> idx,
+        std::array<double, N> values)
         : m_domain(domain)
         , m_coalesc_idx(coalesc_idx)
         , m_idx(idx)
@@ -43,111 +55,42 @@ public:
     {
     }
 
+    Csr(CsrDynamic<HeadTensorIndex, TailTensorIndex...> csr_dyn) : m_domain(csr_dyn.domain())
+    {
+        std::
+                copy_n(csr_dyn.coalesc_idx().begin(),
+                       HeadTensorIndex::size() + 1,
+                       m_coalesc_idx.begin());
+        detail::ArrayOfVectorsToArrayOfArrays<
+                std::make_index_sequence<sizeof...(TailTensorIndex)>>::run(m_idx, csr_dyn.idx());
+        std::copy_n(csr_dyn.values().begin(), N, m_values.begin());
+    }
+
     ddc::DiscreteDomain<HeadTensorIndex, TailTensorIndex...> domain()
     {
         return m_domain;
     }
 
-    std::vector<std::size_t> coalesc_idx()
+    std::array<std::size_t, HeadTensorIndex::size() + 1> coalesc_idx()
     {
         return m_coalesc_idx;
     }
 
-    std::array<std::vector<std::size_t>, sizeof...(TailTensorIndex)> idx()
+    std::array<std::array<std::size_t, N>, sizeof...(TailTensorIndex)> idx()
     {
         return m_idx;
     }
 
-    std::vector<double> values()
+    std::array<double, N> values()
     {
         return m_values;
-    }
-
-    void push_back(sil::tensor::Tensor<
-                   double,
-                   ddc::DiscreteDomain<TailTensorIndex...>,
-                   std::experimental::layout_right,
-                   Kokkos::DefaultHostExecutionSpace::memory_space> dense)
-    {
-        m_coalesc_idx.push_back(m_coalesc_idx.back());
-        ddc::for_each(dense.domain(), [&](ddc::DiscreteElement<TailTensorIndex...> elem) {
-            if (dense(elem) != 0) {
-                m_coalesc_idx.back() += 1;
-                (m_idx[ddc::type_seq_rank_v<
-                               TailTensorIndex,
-                               ddc::detail::TypeSeq<TailTensorIndex...>>]
-                         .push_back(elem.template uid<TailTensorIndex>()),
-                 ...);
-                m_values.push_back(dense(elem));
-            }
-        });
-    }
-
-    // Returns a slice orthogonal to first index
-    Csr<HeadTensorIndex, TailTensorIndex...> get(ddc::DiscreteElement<HeadTensorIndex> id) const
-    {
-        const std::size_t id_begin = m_coalesc_idx[id.uid()];
-        const std::size_t id_end = m_coalesc_idx[id.uid() + 1];
-        std::vector<std::size_t> new_coalesc_idx {0, id_end - id_begin};
-        std::array<std::vector<std::size_t>, sizeof...(TailTensorIndex)> new_idx;
-        ((new_idx[ddc::type_seq_rank_v<TailTensorIndex, ddc::detail::TypeSeq<TailTensorIndex...>>]
-          = std::vector<std::size_t>(
-                  m_idx[ddc::type_seq_rank_v<
-                                TailTensorIndex,
-                                ddc::detail::TypeSeq<TailTensorIndex...>>]
-                                  .begin()
-                          + id_begin,
-                  m_idx[ddc::type_seq_rank_v<
-                                TailTensorIndex,
-                                ddc::detail::TypeSeq<TailTensorIndex...>>]
-                                  .begin()
-                          + id_begin + id_end)),
-         ...);
-        std::vector<double>
-                new_values(m_values.begin() + id_begin, m_values.begin() + id_begin + id_end);
-
-        return Csr<HeadTensorIndex, TailTensorIndex...>(
-                ddc::DiscreteDomain<HeadTensorIndex, TailTensorIndex...>(m_domain),
-                new_coalesc_idx,
-                new_idx,
-                new_values);
-    }
-
-    void write(const std::string& filename, std::string irrep_tag)
-    {
-        std::ofstream file(filename, std::ios::out | std::ios::binary);
-        if (!file) {
-            std::cerr << "Error opening file: " << filename << std::endl;
-            return;
-        }
-        file << irrep_tag << "\n";
-        file
-                .write(reinterpret_cast<const char*>(coalesc_idx().data()),
-                       coalesc_idx().size() * sizeof(std::size_t));
-        file << "\n";
-        for (std::size_t i = 0; i < sizeof...(TailTensorIndex); ++i) {
-            file
-                    .write(reinterpret_cast<const char*>(idx()[i].data()),
-                           idx()[i].size() * sizeof(std::size_t));
-            file << "\n";
-        }
-        file
-                .write(reinterpret_cast<const char*>(values().data()),
-                       m_values.size() * sizeof(double));
-        file << "\n\n";
-        file.close();
-        if (!file.good()) {
-            std::cerr << "Error occurred while writing to file: " << filename << std::endl;
-        } else {
-            std::cout << "File written successfully: " << filename << std::endl;
-        }
     }
 };
 
 /*
  Vector-Csr multiplication 
  */
-template <class HeadTensorIndex, class... TailTensorIndex>
+template <std::size_t N, class HeadTensorIndex, class... TailTensorIndex>
 sil::tensor::Tensor<
         double,
         ddc::DiscreteDomain<TailTensorIndex...>,
@@ -164,7 +107,7 @@ tensor_prod(
                 ddc::DiscreteDomain<HeadTensorIndex>,
                 std::experimental::layout_right,
                 Kokkos::DefaultHostExecutionSpace::memory_space> dense,
-        Csr<HeadTensorIndex, TailTensorIndex...> csr)
+        Csr<N, HeadTensorIndex, TailTensorIndex...> csr)
 {
     ddc::parallel_fill(prod, 0.);
     for (std::size_t i = 0; i < csr.coalesc_idx().size() - 1;
@@ -188,7 +131,7 @@ tensor_prod(
 /*
  Csr-dense multiplication 
  */
-template <class HeadTensorIndex, class... TailTensorIndex>
+template <std::size_t N, class HeadTensorIndex, class... TailTensorIndex>
 sil::tensor::Tensor<
         double,
         ddc::DiscreteDomain<HeadTensorIndex>,
@@ -200,7 +143,7 @@ tensor_prod(
                 ddc::DiscreteDomain<HeadTensorIndex>,
                 std::experimental::layout_right,
                 Kokkos::DefaultHostExecutionSpace::memory_space> prod,
-        Csr<HeadTensorIndex, TailTensorIndex...> csr,
+        Csr<N, HeadTensorIndex, TailTensorIndex...> csr,
         sil::tensor::Tensor<
                 double,
                 ddc::DiscreteDomain<TailTensorIndex...>,
@@ -225,41 +168,6 @@ tensor_prod(
                 prod(ddc::DiscreteElement<HeadTensorIndex>(i)));
     }
     return prod;
-}
-
-
-
-// Convert Csr to dense tensor
-template <class HeadId, class... TailId>
-sil::tensor::Tensor<
-        double,
-        ddc::DiscreteDomain<HeadId, TailId...>,
-        std::experimental::layout_right,
-        Kokkos::DefaultHostExecutionSpace::memory_space>
-csr2dense(
-        sil::tensor::Tensor<
-                double,
-                ddc::DiscreteDomain<HeadId, TailId...>,
-                std::experimental::layout_right,
-                Kokkos::DefaultHostExecutionSpace::memory_space> dense,
-        Csr<HeadId, TailId...> csr)
-{
-    ddc::parallel_fill(dense, 0.);
-    for (std::size_t i = 0; i < csr.coalesc_idx().size() - 1; ++i) {
-        std::size_t const j_begin = csr.coalesc_idx()[i];
-        std::size_t const j_end = csr.coalesc_idx()[i + 1];
-        Kokkos::parallel_for(
-                "csr2dense",
-                Kokkos::RangePolicy<Kokkos::DefaultHostExecutionSpace>(j_begin, j_end),
-                [&](const int j) {
-                    dense(ddc::DiscreteElement<HeadId>(i),
-                          ddc::DiscreteElement<TailId...>(csr.idx()[ddc::type_seq_rank_v<
-                                  TailId,
-                                  ddc::detail::TypeSeq<TailId...>>][j]...))
-                            = csr.values()[j];
-                });
-    }
-    return dense;
 }
 
 } // namespace csr

--- a/src/csr/csr.hpp
+++ b/src/csr/csr.hpp
@@ -122,7 +122,17 @@ public:
         }
         file << irrep_tag << "\n";
         file
-                .write(reinterpret_cast<const char*>(m_values.data()),
+                .write(reinterpret_cast<const char*>(coalesc_idx().data()),
+                       coalesc_idx().size() * sizeof(std::size_t));
+        file << "\n";
+        for (std::size_t i = 0; i < sizeof...(TailTensorIndex); ++i) {
+            file
+                    .write(reinterpret_cast<const char*>(idx()[i].data()),
+                           idx()[i].size() * sizeof(std::size_t));
+            file << "\n";
+        }
+        file
+                .write(reinterpret_cast<const char*>(values().data()),
                        m_values.size() * sizeof(double));
         file << "\n\n";
         file.close();

--- a/src/csr/csr.hpp
+++ b/src/csr/csr.hpp
@@ -113,13 +113,14 @@ public:
                 new_values);
     }
 
-    void write(const std::string& filename)
+    void write(const std::string& filename, std::string irrep_tag)
     {
         std::ofstream file(filename, std::ios::out | std::ios::binary);
         if (!file) {
             std::cerr << "Error opening file: " << filename << std::endl;
             return;
         }
+        file << irrep_tag << "\n";
         file
                 .write(reinterpret_cast<const char*>(m_values.data()),
                        m_values.size() * sizeof(double));

--- a/src/csr/csr.hpp
+++ b/src/csr/csr.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <fstream>
+
 #include <ddc/ddc.hpp>
 
 #include "tensor_impl.hpp"
@@ -109,6 +111,24 @@ public:
                 new_coalesc_idx,
                 new_idx,
                 new_values);
+    }
+
+    void write(const std::string& filename)
+    {
+        std::ofstream file(filename, std::ios::out | std::ios::binary);
+        if (!file) {
+            std::cerr << "Error opening file: " << filename << std::endl;
+            return;
+        }
+        file
+                .write(reinterpret_cast<const char*>(m_values.data()),
+                       m_values.size() * sizeof(double));
+        file.close();
+        if (!file.good()) {
+            std::cerr << "Error occurred while writing to file: " << filename << std::endl;
+        } else {
+            std::cout << "File written successfully: " << filename << std::endl;
+        }
     }
 };
 

--- a/src/csr/csr.hpp
+++ b/src/csr/csr.hpp
@@ -124,6 +124,7 @@ public:
         file
                 .write(reinterpret_cast<const char*>(m_values.data()),
                        m_values.size() * sizeof(double));
+        file << "\n\n";
         file.close();
         if (!file.good()) {
             std::cerr << "Error occurred while writing to file: " << filename << std::endl;

--- a/src/csr/csr_dynamic.hpp
+++ b/src/csr/csr_dynamic.hpp
@@ -1,0 +1,184 @@
+// SPDX-FileCopyrightText: 2024 Baptiste Legouix
+// SPDX-License-Identifier: GPL-3.0
+
+#pragma once
+
+#include <fstream>
+
+#include <ddc/ddc.hpp>
+
+#include "tensor_impl.hpp"
+
+namespace sil {
+
+namespace csr {
+
+// Only natural indexing supported
+template <class HeadTensorIndex, class... TailTensorIndex>
+class CsrDynamic
+{
+private:
+    ddc::DiscreteDomain<HeadTensorIndex, TailTensorIndex...> m_domain;
+    std::vector<std::size_t> m_coalesc_idx;
+    std::array<std::vector<std::size_t>, sizeof...(TailTensorIndex)> m_idx;
+    std::vector<double> m_values;
+
+public:
+    CsrDynamic(ddc::DiscreteDomain<HeadTensorIndex, TailTensorIndex...> domain)
+        : m_domain(domain)
+        , m_coalesc_idx({0})
+        , m_idx()
+        , m_values()
+    {
+    }
+
+    CsrDynamic(
+            ddc::DiscreteDomain<HeadTensorIndex, TailTensorIndex...> domain,
+            std::vector<std::size_t> coalesc_idx,
+            std::array<std::vector<std::size_t>, sizeof...(TailTensorIndex)> idx,
+            std::vector<double> values)
+        : m_domain(domain)
+        , m_coalesc_idx(coalesc_idx)
+        , m_idx(idx)
+        , m_values(values)
+    {
+    }
+
+    ddc::DiscreteDomain<HeadTensorIndex, TailTensorIndex...> domain()
+    {
+        return m_domain;
+    }
+
+    std::vector<std::size_t> coalesc_idx()
+    {
+        return m_coalesc_idx;
+    }
+
+    std::array<std::vector<std::size_t>, sizeof...(TailTensorIndex)> idx()
+    {
+        return m_idx;
+    }
+
+    std::vector<double> values()
+    {
+        return m_values;
+    }
+
+    void push_back(sil::tensor::Tensor<
+                   double,
+                   ddc::DiscreteDomain<TailTensorIndex...>,
+                   std::experimental::layout_right,
+                   Kokkos::DefaultHostExecutionSpace::memory_space> dense)
+    {
+        m_coalesc_idx.push_back(m_coalesc_idx.back());
+        ddc::for_each(dense.domain(), [&](ddc::DiscreteElement<TailTensorIndex...> elem) {
+            if (dense(elem) != 0) {
+                m_coalesc_idx.back() += 1;
+                (m_idx[ddc::type_seq_rank_v<
+                               TailTensorIndex,
+                               ddc::detail::TypeSeq<TailTensorIndex...>>]
+                         .push_back(elem.template uid<TailTensorIndex>()),
+                 ...);
+                m_values.push_back(dense(elem));
+            }
+        });
+    }
+
+    // Returns a slice orthogonal to first index
+    CsrDynamic<HeadTensorIndex, TailTensorIndex...> get(
+            ddc::DiscreteElement<HeadTensorIndex> id) const
+    {
+        const std::size_t id_begin = m_coalesc_idx[id.uid()];
+        const std::size_t id_end = m_coalesc_idx[id.uid() + 1];
+        std::vector<std::size_t> new_coalesc_idx {0, id_end - id_begin};
+        std::array<std::vector<std::size_t>, sizeof...(TailTensorIndex)> new_idx;
+        ((new_idx[ddc::type_seq_rank_v<TailTensorIndex, ddc::detail::TypeSeq<TailTensorIndex...>>]
+          = std::vector<std::size_t>(
+                  m_idx[ddc::type_seq_rank_v<
+                                TailTensorIndex,
+                                ddc::detail::TypeSeq<TailTensorIndex...>>]
+                                  .begin()
+                          + id_begin,
+                  m_idx[ddc::type_seq_rank_v<
+                                TailTensorIndex,
+                                ddc::detail::TypeSeq<TailTensorIndex...>>]
+                                  .begin()
+                          + id_begin + id_end)),
+         ...);
+        std::vector<double>
+                new_values(m_values.begin() + id_begin, m_values.begin() + id_begin + id_end);
+
+        return CsrDynamic<HeadTensorIndex, TailTensorIndex...>(
+                ddc::DiscreteDomain<HeadTensorIndex, TailTensorIndex...>(m_domain),
+                new_coalesc_idx,
+                new_idx,
+                new_values);
+    }
+
+    void write(const std::string& filename, std::string irrep_tag)
+    {
+        std::ofstream file(filename, std::ios::out | std::ios::binary);
+        if (!file) {
+            std::cerr << "Error opening file: " << filename << std::endl;
+            return;
+        }
+        file << irrep_tag << "\n";
+        file
+                .write(reinterpret_cast<const char*>(coalesc_idx().data()),
+                       coalesc_idx().size() * sizeof(std::size_t));
+        file << "\n";
+        for (std::size_t i = 0; i < sizeof...(TailTensorIndex); ++i) {
+            file
+                    .write(reinterpret_cast<const char*>(idx()[i].data()),
+                           idx()[i].size() * sizeof(std::size_t));
+            file << "\n";
+        }
+        file
+                .write(reinterpret_cast<const char*>(values().data()),
+                       m_values.size() * sizeof(double));
+        file << "\n\n";
+        file.close();
+        if (!file.good()) {
+            std::cerr << "Error occurred while writing to file: " << filename << std::endl;
+        } else {
+            std::cout << "File written successfully: " << filename << std::endl;
+        }
+    }
+};
+
+// Convert Csr to dense tensor
+template <class HeadId, class... TailId>
+sil::tensor::Tensor<
+        double,
+        ddc::DiscreteDomain<HeadId, TailId...>,
+        std::experimental::layout_right,
+        Kokkos::DefaultHostExecutionSpace::memory_space>
+csr2dense(
+        sil::tensor::Tensor<
+                double,
+                ddc::DiscreteDomain<HeadId, TailId...>,
+                std::experimental::layout_right,
+                Kokkos::DefaultHostExecutionSpace::memory_space> dense,
+        CsrDynamic<HeadId, TailId...> csr)
+{
+    ddc::parallel_fill(dense, 0.);
+    for (std::size_t i = 0; i < csr.coalesc_idx().size() - 1; ++i) {
+        std::size_t const j_begin = csr.coalesc_idx()[i];
+        std::size_t const j_end = csr.coalesc_idx()[i + 1];
+        Kokkos::parallel_for(
+                "csr2dense",
+                Kokkos::RangePolicy<Kokkos::DefaultHostExecutionSpace>(j_begin, j_end),
+                [&](const int j) {
+                    dense(ddc::DiscreteElement<HeadId>(i),
+                          ddc::DiscreteElement<TailId...>(csr.idx()[ddc::type_seq_rank_v<
+                                  TailId,
+                                  ddc::detail::TypeSeq<TailId...>>][j]...))
+                            = csr.values()[j];
+                });
+    }
+    return dense;
+}
+
+} // namespace csr
+
+} // namespace sil

--- a/src/csr/csr_dynamic.hpp
+++ b/src/csr/csr_dynamic.hpp
@@ -115,14 +115,8 @@ public:
                 new_values);
     }
 
-    void write(const std::string& filename, std::string irrep_tag)
+    void write(std::ofstream& file)
     {
-        std::ofstream file(filename, std::ios::out | std::ios::binary);
-        if (!file) {
-            std::cerr << "Error opening file: " << filename << std::endl;
-            return;
-        }
-        file << irrep_tag << "\n";
         file
                 .write(reinterpret_cast<const char*>(coalesc_idx().data()),
                        coalesc_idx().size() * sizeof(std::size_t));
@@ -136,13 +130,7 @@ public:
         file
                 .write(reinterpret_cast<const char*>(values().data()),
                        m_values.size() * sizeof(double));
-        file << "\n\n";
-        file.close();
-        if (!file.good()) {
-            std::cerr << "Error occurred while writing to file: " << filename << std::endl;
-        } else {
-            std::cout << "File written successfully: " << filename << std::endl;
-        }
+        file << "\n";
     }
 };
 

--- a/src/tensor/antisymmetric_tensor.hpp
+++ b/src/tensor/antisymmetric_tensor.hpp
@@ -42,7 +42,7 @@ struct AntisymmetricTensorIndex
     static constexpr std::pair<std::vector<double>, std::vector<std::size_t>> mem_id()
     {
         // static_assert(rank() == sizeof...(CDim));
-        std::array<int, sizeof...(TensorIndex)> sorted_ids {
+        std::array<std::size_t, sizeof...(TensorIndex)> sorted_ids {
                 detail::access_id<TensorIndex, ddc::detail::TypeSeq<TensorIndex...>, CDim...>()...};
         std::sort(sorted_ids.begin(), sorted_ids.end());
         return std::pair<std::vector<double>, std::vector<std::size_t>>(
@@ -81,7 +81,7 @@ private:
     template <class... CDim>
     static constexpr bool permutation_parity()
     {
-        std::array<int, sizeof...(TensorIndex)> ids {
+        std::array<std::size_t, sizeof...(TensorIndex)> ids {
                 detail::access_id<TensorIndex, ddc::detail::TypeSeq<TensorIndex...>, CDim...>()...};
         bool cnt = false;
         for (int i = 0; i < sizeof...(CDim); i++)

--- a/src/tensor/symmetric_tensor.hpp
+++ b/src/tensor/symmetric_tensor.hpp
@@ -43,7 +43,7 @@ struct SymmetricTensorIndex
     static constexpr std::pair<std::vector<double>, std::vector<std::size_t>> mem_id()
     {
         // static_assert(rank() == sizeof...(CDim));
-        std::array<int, sizeof...(TensorIndex)> sorted_ids {
+        std::array<std::size_t, sizeof...(TensorIndex)> sorted_ids {
                 detail::access_id<TensorIndex, ddc::detail::TypeSeq<TensorIndex...>, CDim...>()...};
         std::sort(sorted_ids.begin(), sorted_ids.end());
         return std::pair<std::vector<double>, std::vector<std::size_t>>(

--- a/src/tensor/young_tableau_tensor.hpp
+++ b/src/tensor/young_tableau_tensor.hpp
@@ -16,7 +16,7 @@ namespace tensor {
 template <class YoungTableau, class... TensorIndex>
 struct YoungTableauTensorIndex
 {
-    using young_tableau =  YoungTableau;
+    using young_tableau = YoungTableau;
 
     static constexpr std::size_t rank()
     {

--- a/src/tensor/young_tableau_tensor.hpp
+++ b/src/tensor/young_tableau_tensor.hpp
@@ -16,13 +16,7 @@ namespace tensor {
 template <class YoungTableau, class... TensorIndex>
 struct YoungTableauTensorIndex
 {
-    static constexpr YoungTableau s_young_tableau = YoungTableau();
-
-public:
-    static constexpr YoungTableau young_tableau()
-    {
-        return s_young_tableau;
-    }
+    using young_tableau =  YoungTableau;
 
     static constexpr std::size_t rank()
     {

--- a/src/young_tableau/young_tableau.hpp
+++ b/src/young_tableau/young_tableau.hpp
@@ -9,6 +9,7 @@
 #include <boost/math/special_functions/factorials.hpp>
 
 #include "csr.hpp"
+#include "csr_dynamic.hpp"
 #include "tensor_impl.hpp"
 
 namespace sil {
@@ -494,7 +495,7 @@ orthogonalize(
         sil::tensor::
                 Tensor<ElementType, ddc::DiscreteDomain<Id...>, LayoutStridedPolicy, MemorySpace>
                         tensor,
-        sil::csr::Csr<BasisId, Id...> basis,
+        sil::csr::CsrDynamic<BasisId, Id...> basis,
         std::size_t max_basis_id)
 {
     ddc::Chunk eigentensor_alloc(
@@ -555,7 +556,7 @@ std::vector<bool> index_hamming_weight_code(std::size_t index, std::size_t lengt
     return bits;
 }
 
-// Dummy tag used by OrthonormalBasisSubspaceEigenvalueOne (coalescent dimension of the Csr storage)
+// Dummy tag used by OrthonormalBasisSubspaceEigenvalueOne (coalescent dimension of the CsrDynamic storage)
 struct BasisId
 {
 };
@@ -589,8 +590,8 @@ template <class... Id>
 struct OrthonormalBasisSubspaceEigenvalueOne<sil::tensor::FullTensorIndex<Id...>>
 {
     template <class YoungTableau>
-    static std::pair<sil::csr::Csr<BasisId, Id...>, sil::csr::Csr<BasisId, Id...>> run(
-            YoungTableau tableau)
+    static std::pair<sil::csr::CsrDynamic<BasisId, Id...>, sil::csr::CsrDynamic<BasisId, Id...>>
+    run(YoungTableau tableau)
     {
         auto [proj_alloc, proj] = tableau.template projector<Id...>();
 
@@ -620,8 +621,8 @@ struct OrthonormalBasisSubspaceEigenvalueOne<sil::tensor::FullTensorIndex<Id...>
                         ddc::DiscreteElement<BasisId>(0),
                         ddc::DiscreteVector<BasisId>(tableau.irrep_dim())),
                 candidate_dom);
-        sil::csr::Csr<BasisId, Id...> u(basis_dom);
-        sil::csr::Csr<BasisId, Id...> v(basis_dom);
+        sil::csr::CsrDynamic<BasisId, Id...> u(basis_dom);
+        sil::csr::CsrDynamic<BasisId, Id...> v(basis_dom);
         std::size_t n_irreps = 0;
         std::size_t index = 0;
         while (n_irreps < tableau.irrep_dim()) {
@@ -664,11 +665,13 @@ struct OrthonormalBasisSubspaceEigenvalueOne<sil::tensor::FullTensorIndex<Id...>
                 n_irreps++;
             }
         }
-        return std::pair<sil::csr::Csr<BasisId, Id...>, sil::csr::Csr<BasisId, Id...>>(u, v);
+        return std::pair<
+                sil::csr::CsrDynamic<BasisId, Id...>,
+                sil::csr::CsrDynamic<BasisId, Id...>>(u, v);
     }
 };
 
-// Load binary files and build u and v static constexpr Csr at compile-time
+// Load binary files and build u and v static constexpr CsrDynamic at compile-time
 template <std::size_t Line>
 consteval std::string_view load_irrep_line_for_tag(std::string_view const irrep_tag)
 {

--- a/src/young_tableau/young_tableau.hpp
+++ b/src/young_tableau/young_tableau.hpp
@@ -8,8 +8,6 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/math/special_functions/factorials.hpp>
 
-#include "../../vendor/constexpr-to-string/to_string.hpp"
-
 #include "csr.hpp"
 #include "csr_dynamic.hpp"
 #include "tensor_impl.hpp"

--- a/src/young_tableau/young_tableau.hpp
+++ b/src/young_tableau/young_tableau.hpp
@@ -825,7 +825,7 @@ public:
         auto [u, v] = detail::OrthonormalBasisSubspaceEigenvalueOne<
                 detail::dummy_index_t<s_d, s_r>>::run(*this);
 
-        std::ofstream file(IRREPS_DICT_PATH, std::ios::out | std::ios::binary);
+        std::ofstream file(IRREPS_DICT_PATH, std::ios::app | std::ios::binary);
         if (!file) {
             std::cerr << "Error opening file: " << IRREPS_DICT_PATH << std::endl;
             return;

--- a/src/young_tableau/young_tableau.hpp
+++ b/src/young_tableau/young_tableau.hpp
@@ -608,7 +608,7 @@ struct OrthonormalBasisSubspaceEigenvalueOne<sil::tensor::FullTensorIndex<Id...>
         sil::tensor::Tensor<
                 double,
                 sil::tensor::tensor_prod_domain_t<
-                        typename YoungTableau::projector_domain<Id...>,
+                        typename YoungTableau::template projector_domain<Id...>,
                         ddc::DiscreteDomain<Id...>>,
                 std::experimental::layout_right,
                 Kokkos::DefaultHostExecutionSpace::memory_space>
@@ -725,6 +725,18 @@ constexpr YoungTableau<Dimension, TableauSeq>::YoungTableau()
     auto [u, v]
             = detail::OrthonormalBasisSubspaceEigenvalueOne<detail::dummy_index_t<s_d, s_r>>::run(
                     *this);
+
+    u.write("testfile");
+    constexpr char test_raw[] = {
+#embed "/home/cart3sianbear/SimiLie/build/tests/tensor/testfile"
+    };
+
+    std::vector<double>
+            test(reinterpret_cast<const double*>(test_raw),
+                 reinterpret_cast<const double*>(test_raw) + u.values().size());
+    for (std::size_t i = 0; i < u.values().size(); ++i) {
+        std::cout << u.values()[i] << " " << test[i] << "\n";
+    }
 }
 
 namespace detail {

--- a/tests/tensor/tensor.cpp
+++ b/tests/tensor/tensor.cpp
@@ -484,18 +484,6 @@ struct YoungTableauIndex
 {
 };
 
-struct YoungTableauIndex2
-    : sil::tensor::YoungTableauTensorIndex<
-              sil::young_tableau::YoungTableau<
-                      4,
-                      sil::young_tableau::
-                              YoungTableauSeq<std::index_sequence<1, 2>, std::index_sequence<3>>>,
-              Alpha,
-              Beta,
-              Gamma>
-{
-};
-
 TEST(Tensor, YoungTableauIndexing)
 {
     sil::tensor::TensorAccessor<YoungTableauIndex> tensor_accessor;

--- a/tests/tensor/tensor.cpp
+++ b/tests/tensor/tensor.cpp
@@ -495,9 +495,10 @@ TEST(Tensor, YoungTableauIndexing)
             std::experimental::layout_right,
             Kokkos::DefaultHostExecutionSpace::memory_space>
             tensor(tensor_alloc);
-    sil::young_tableau::YoungTableau<
-                      3,
-                      sil::young_tableau::YoungTableauSeq<std::index_sequence<1, 2, 3>>> young_tableau;
+    sil::young_tableau::
+            YoungTableau<3, sil::young_tableau::YoungTableauSeq<std::index_sequence<1, 2, 3>>>
+                    young_tableau {};
+    young_tableau.print_u();
     // SymIndex3x3x3::young_tableau().print_representation_absent();
 
     /*

--- a/tests/tensor/tensor.cpp
+++ b/tests/tensor/tensor.cpp
@@ -484,6 +484,18 @@ struct YoungTableauIndex
 {
 };
 
+struct YoungTableauIndex2
+    : sil::tensor::YoungTableauTensorIndex<
+              sil::young_tableau::YoungTableau<
+                      4,
+                      sil::young_tableau::
+                              YoungTableauSeq<std::index_sequence<1, 2>, std::index_sequence<3>>>,
+              Alpha,
+              Beta,
+              Gamma>
+{
+};
+
 TEST(Tensor, YoungTableauIndexing)
 {
     sil::tensor::TensorAccessor<YoungTableauIndex> tensor_accessor;
@@ -499,6 +511,10 @@ TEST(Tensor, YoungTableauIndexing)
             YoungTableau<3, sil::young_tableau::YoungTableauSeq<std::index_sequence<1, 2, 3>>>
                     young_tableau {};
     young_tableau.print_u();
+    sil::young_tableau::YoungTableau<
+            3,
+            sil::young_tableau::YoungTableauSeq<std::index_sequence<1, 2>, std::index_sequence<3>>>
+            young_tableau2 {};
     // SymIndex3x3x3::young_tableau().print_representation_absent();
 
     /*

--- a/tests/tensor/tensor.cpp
+++ b/tests/tensor/tensor.cpp
@@ -513,7 +513,10 @@ TEST(Tensor, YoungTableauIndexing)
     young_tableau.print_u();
     sil::young_tableau::YoungTableau<
             3,
-            sil::young_tableau::YoungTableauSeq<std::index_sequence<1, 2>, std::index_sequence<3>>>
+            sil::young_tableau::YoungTableauSeq<
+                    std::index_sequence<1>,
+                    std::index_sequence<2>,
+                    std::index_sequence<3>>>
             young_tableau2 {};
     // SymIndex3x3x3::young_tableau().print_representation_absent();
 

--- a/tests/tensor/tensor.cpp
+++ b/tests/tensor/tensor.cpp
@@ -495,6 +495,9 @@ TEST(Tensor, YoungTableauIndexing)
             std::experimental::layout_right,
             Kokkos::DefaultHostExecutionSpace::memory_space>
             tensor(tensor_alloc);
+    sil::young_tableau::YoungTableau<
+                      3,
+                      sil::young_tableau::YoungTableauSeq<std::index_sequence<1, 2, 3>>> young_tableau;
     // SymIndex3x3x3::young_tableau().print_representation_absent();
 
     /*


### PR DESCRIPTION
The irreductible representation (U and V `Csr `objects) are build at runtime and stored in .bin file. The file is then loaded during compilation and used to fill a `static constexpr YoungTableau::s_irrep `object. Because this is `constexpr`, compiler is expected to perform optimizations in tensor products etc... that are not implemented yet.

- Rely on the #embed directive from C23 -> **Only tested with clang 19**
- Previous `Csr `class is renamed `CsrDynamic `because based on `std::vector`s. A new `Csr` class is based on `std::array`
- An irrep tag (string like `1_2l3d4` is generated at compile-time to identify the Young tableau.