### PR TITLE
Compress/uncompress tensor indexed with YoungTensorIndex

### DIFF
--- a/src/csr/csr.hpp
+++ b/src/csr/csr.hpp
@@ -39,13 +39,13 @@ class Csr
 {
 private:
     ddc::DiscreteDomain<HeadTensorIndex, TailTensorIndex...> m_domain;
-    std::array<std::size_t, HeadTensorIndex::size() + 1> m_coalesc_idx;
+    std::array<std::size_t, HeadTensorIndex::mem_size() + 1> m_coalesc_idx;
     std::array<std::array<std::size_t, N>, sizeof...(TailTensorIndex)> m_idx;
     std::array<double, N> m_values;
 
 public:
     Csr(ddc::DiscreteDomain<HeadTensorIndex, TailTensorIndex...> domain,
-        std::array<std::size_t, HeadTensorIndex::size() + 1> coalesc_idx,
+        std::array<std::size_t, HeadTensorIndex::mem_size() + 1> coalesc_idx,
         std::array<std::array<std::size_t, N>, sizeof...(TailTensorIndex)> idx,
         std::array<double, N> values)
         : m_domain(domain)
@@ -59,7 +59,7 @@ public:
     {
         std::
                 copy_n(csr_dyn.coalesc_idx().begin(),
-                       HeadTensorIndex::size() + 1,
+                       HeadTensorIndex::mem_size() + 1,
                        m_coalesc_idx.begin());
         detail::ArrayOfVectorsToArrayOfArrays<
                 std::make_index_sequence<sizeof...(TailTensorIndex)>>::run(m_idx, csr_dyn.idx());
@@ -71,7 +71,7 @@ public:
         return m_domain;
     }
 
-    std::array<std::size_t, HeadTensorIndex::size() + 1> coalesc_idx()
+    std::array<std::size_t, HeadTensorIndex::mem_size() + 1> coalesc_idx()
     {
         return m_coalesc_idx;
     }

--- a/src/csr/csr_dynamic.hpp
+++ b/src/csr/csr_dynamic.hpp
@@ -120,17 +120,17 @@ public:
         file
                 .write(reinterpret_cast<const char*>(coalesc_idx().data()),
                        coalesc_idx().size() * sizeof(std::size_t));
-        file << "\n";
+        file << "break\n";
         for (std::size_t i = 0; i < sizeof...(TailTensorIndex); ++i) {
             file
                     .write(reinterpret_cast<const char*>(idx()[i].data()),
                            idx()[i].size() * sizeof(std::size_t));
-            file << "\n";
+            file << "break\n";
         }
         file
                 .write(reinterpret_cast<const char*>(values().data()),
                        m_values.size() * sizeof(double));
-        file << "\n";
+        file << "break\n";
     }
 };
 

--- a/src/tensor/young_tableau_tensor.hpp
+++ b/src/tensor/young_tableau_tensor.hpp
@@ -86,6 +86,55 @@ struct IsTensorIndex<YoungTableauTensorIndex<YoungTableau, SubIndex...>>
 
 } // namespace detail
 
+// Compress & uncompress (multiply by young_tableau.u or young_tableau.v
+template <class YoungTableauIndex, class... Id>
+sil::tensor::Tensor<
+        double,
+        ddc::DiscreteDomain<YoungTableauIndex>,
+        std::experimental::layout_right,
+        Kokkos::DefaultHostExecutionSpace::memory_space>
+compress(
+        sil::tensor::Tensor<
+                double,
+                ddc::DiscreteDomain<YoungTableauIndex>,
+                std::experimental::layout_right,
+                Kokkos::DefaultHostExecutionSpace::memory_space> compressed,
+        sil::tensor::Tensor<
+                double,
+                ddc::DiscreteDomain<Id...>,
+                std::experimental::layout_right,
+                Kokkos::DefaultHostExecutionSpace::memory_space> tensor)
+{
+    typename YoungTableauIndex::young_tableau young_tableau;
+    sil::csr::Csr u = young_tableau.template u<YoungTableauIndex, Id...>(tensor.domain());
+
+    return sil::csr::tensor_prod(compressed, u, tensor);
+}
+
+template <class YoungTableauIndex, class... Id>
+sil::tensor::Tensor<
+        double,
+        ddc::DiscreteDomain<Id...>,
+        std::experimental::layout_right,
+        Kokkos::DefaultHostExecutionSpace::memory_space>
+uncompress(
+        sil::tensor::Tensor<
+                double,
+                ddc::DiscreteDomain<Id...>,
+                std::experimental::layout_right,
+                Kokkos::DefaultHostExecutionSpace::memory_space> uncompressed,
+        sil::tensor::Tensor<
+                double,
+                ddc::DiscreteDomain<YoungTableauIndex>,
+                std::experimental::layout_right,
+                Kokkos::DefaultHostExecutionSpace::memory_space> tensor)
+{
+    typename YoungTableauIndex::young_tableau young_tableau;
+    sil::csr::Csr v = young_tableau.template v<YoungTableauIndex, Id...>(uncompressed.domain());
+
+    return sil::csr::tensor_prod(uncompressed, tensor, v);
+}
+
 } // namespace tensor
 
 } // namespace sil

--- a/tests/tensor/tensor.cpp
+++ b/tests/tensor/tensor.cpp
@@ -486,6 +486,44 @@ struct YoungTableauIndex
 
 TEST(Tensor, YoungTableauIndexing)
 {
+    sil::tensor::TensorAccessor<Alpha, Beta, Gamma> natural_accessor;
+    ddc::DiscreteDomain<Alpha, Beta, Gamma> natural_dom = natural_accessor.mem_domain();
+    ddc::Chunk natural_alloc(natural_dom, ddc::HostAllocator<double>());
+    sil::tensor::Tensor<
+            double,
+            ddc::DiscreteDomain<Alpha, Beta, Gamma>,
+            std::experimental::layout_right,
+            Kokkos::DefaultHostExecutionSpace::memory_space>
+            natural(natural_alloc);
+
+    natural(natural_accessor.element<X, X, X>()) = 0.;
+    natural(natural_accessor.element<X, X, Y>()) = 1.;
+    natural(natural_accessor.element<X, X, Z>()) = 2.;
+    natural(natural_accessor.element<X, Y, X>()) = 1.;
+    natural(natural_accessor.element<X, Y, Y>()) = 3.;
+    natural(natural_accessor.element<X, Y, Z>()) = 4.;
+    natural(natural_accessor.element<X, Z, X>()) = 2.;
+    natural(natural_accessor.element<X, Z, Y>()) = 4.;
+    natural(natural_accessor.element<X, Z, Z>()) = 5.;
+    natural(natural_accessor.element<Y, X, X>()) = 1.;
+    natural(natural_accessor.element<Y, X, Y>()) = 3.;
+    natural(natural_accessor.element<Y, X, Z>()) = 4.;
+    natural(natural_accessor.element<Y, Y, X>()) = 3.;
+    natural(natural_accessor.element<Y, Y, Y>()) = 6.;
+    natural(natural_accessor.element<Y, Y, Z>()) = 7.;
+    natural(natural_accessor.element<Y, Z, X>()) = 4.;
+    natural(natural_accessor.element<Y, Z, Y>()) = 7.;
+    natural(natural_accessor.element<Y, Z, Z>()) = 8.;
+    natural(natural_accessor.element<Z, X, X>()) = 2.;
+    natural(natural_accessor.element<Z, X, Y>()) = 4.;
+    natural(natural_accessor.element<Z, X, Z>()) = 5.;
+    natural(natural_accessor.element<Z, Y, X>()) = 4.;
+    natural(natural_accessor.element<Z, Y, Y>()) = 7.;
+    natural(natural_accessor.element<Z, Y, Z>()) = 8.;
+    natural(natural_accessor.element<Z, Z, X>()) = 5.;
+    natural(natural_accessor.element<Z, Z, Y>()) = 8.;
+    natural(natural_accessor.element<Z, Z, Z>()) = 9.;
+
     sil::tensor::TensorAccessor<YoungTableauIndex> tensor_accessor;
     ddc::DiscreteDomain<YoungTableauIndex> tensor_dom = tensor_accessor.mem_domain();
     ddc::Chunk tensor_alloc(tensor_dom, ddc::HostAllocator<double>());
@@ -495,65 +533,46 @@ TEST(Tensor, YoungTableauIndexing)
             std::experimental::layout_right,
             Kokkos::DefaultHostExecutionSpace::memory_space>
             tensor(tensor_alloc);
-    sil::young_tableau::
-            YoungTableau<3, sil::young_tableau::YoungTableauSeq<std::index_sequence<1, 2, 3>>>
-                    young_tableau {};
-    young_tableau.print_u();
-    sil::young_tableau::YoungTableau<
-            3,
-            sil::young_tableau::YoungTableauSeq<
-                    std::index_sequence<1>,
-                    std::index_sequence<2>,
-                    std::index_sequence<3>>>
-            young_tableau2 {};
-    // SymIndex3x3x3::young_tableau().print_representation_absent();
 
-    /*
-    for (int i = 0; i < 10; ++i) {
-        tensor(ddc::DiscreteElement<SymIndex3x3x3>(i)) = i;
-    }
-    */
+    sil::tensor::compress(tensor, natural);
 
-    /*
-    tensor(tensor_accessor.element<X, X, X>()) = 0.;
-    tensor(tensor_accessor.element<X, X, Y>()) = 1.;
-    tensor(tensor_accessor.element<X, X, Z>()) = 2.;
-    tensor(tensor_accessor.element<X, Y, Y>()) = 3.;
-    tensor(tensor_accessor.element<X, Y, Z>()) = 4.;
-    tensor(tensor_accessor.element<X, Z, Z>()) = 5.;
-    tensor(tensor_accessor.element<Y, Y, Y>()) = 6.;
-    tensor(tensor_accessor.element<Y, Y, Z>()) = 7.;
-    tensor(tensor_accessor.element<Y, Z, Z>()) = 8.;
-    tensor(tensor_accessor.element<Z, Z, Z>()) = 9.;
+    ddc::Chunk uncompressed_alloc(natural_dom, ddc::HostAllocator<double>());
+    sil::tensor::Tensor<
+            double,
+            ddc::DiscreteDomain<Alpha, Beta, Gamma>,
+            std::experimental::layout_right,
+            Kokkos::DefaultHostExecutionSpace::memory_space>
+            uncompressed(uncompressed_alloc);
 
-    EXPECT_EQ(tensor.get(tensor_accessor.element<X, X, X>()), 0.);
-    EXPECT_EQ(tensor.get(tensor_accessor.element<X, X, Y>()), 1.);
-    EXPECT_EQ(tensor.get(tensor_accessor.element<X, X, Z>()), 2.);
-    EXPECT_EQ(tensor.get(tensor_accessor.element<X, Y, X>()), 1.);
-    EXPECT_EQ(tensor.get(tensor_accessor.element<X, Y, Y>()), 3.);
-    EXPECT_EQ(tensor.get(tensor_accessor.element<X, Y, Z>()), 4.);
-    EXPECT_EQ(tensor.get(tensor_accessor.element<X, Z, X>()), 2.);
-    EXPECT_EQ(tensor.get(tensor_accessor.element<X, Z, Y>()), 4.);
-    EXPECT_EQ(tensor.get(tensor_accessor.element<X, Z, Z>()), 5.);
-    EXPECT_EQ(tensor.get(tensor_accessor.element<Y, X, X>()), 1.);
-    EXPECT_EQ(tensor.get(tensor_accessor.element<Y, X, Y>()), 3.);
-    EXPECT_EQ(tensor.get(tensor_accessor.element<Y, X, Z>()), 4.);
-    EXPECT_EQ(tensor.get(tensor_accessor.element<Y, Y, X>()), 3.);
-    EXPECT_EQ(tensor.get(tensor_accessor.element<Y, Y, Y>()), 6.);
-    EXPECT_EQ(tensor.get(tensor_accessor.element<Y, Y, Z>()), 7.);
-    EXPECT_EQ(tensor.get(tensor_accessor.element<Y, Z, X>()), 4.);
-    EXPECT_EQ(tensor.get(tensor_accessor.element<Y, Z, Y>()), 7.);
-    EXPECT_EQ(tensor.get(tensor_accessor.element<Y, Z, Z>()), 8.);
-    EXPECT_EQ(tensor.get(tensor_accessor.element<Z, X, X>()), 2.);
-    EXPECT_EQ(tensor.get(tensor_accessor.element<Z, X, Y>()), 4.);
-    EXPECT_EQ(tensor.get(tensor_accessor.element<Z, X, Z>()), 5.);
-    EXPECT_EQ(tensor.get(tensor_accessor.element<Z, Y, X>()), 4.);
-    EXPECT_EQ(tensor.get(tensor_accessor.element<Z, Y, Y>()), 7.);
-    EXPECT_EQ(tensor.get(tensor_accessor.element<Z, Y, Z>()), 8.);
-    EXPECT_EQ(tensor.get(tensor_accessor.element<Z, Z, X>()), 5.);
-    EXPECT_EQ(tensor.get(tensor_accessor.element<Z, Z, Y>()), 8.);
-    EXPECT_EQ(tensor.get(tensor_accessor.element<Z, Z, Z>()), 9.);
-*/
+    sil::tensor::uncompress(uncompressed, tensor);
+
+    EXPECT_DOUBLE_EQ(uncompressed.get(natural_accessor.element<X, X, X>()), 0.);
+    EXPECT_DOUBLE_EQ(uncompressed.get(natural_accessor.element<X, X, Y>()), 1.);
+    EXPECT_DOUBLE_EQ(uncompressed.get(natural_accessor.element<X, X, Z>()), 2.);
+    EXPECT_DOUBLE_EQ(uncompressed.get(natural_accessor.element<X, Y, X>()), 1.);
+    EXPECT_DOUBLE_EQ(uncompressed.get(natural_accessor.element<X, Y, Y>()), 3.);
+    EXPECT_DOUBLE_EQ(uncompressed.get(natural_accessor.element<X, Y, Z>()), 4.);
+    EXPECT_DOUBLE_EQ(uncompressed.get(natural_accessor.element<X, Z, X>()), 2.);
+    EXPECT_DOUBLE_EQ(uncompressed.get(natural_accessor.element<X, Z, Y>()), 4.);
+    EXPECT_DOUBLE_EQ(uncompressed.get(natural_accessor.element<X, Z, Z>()), 5.);
+    EXPECT_DOUBLE_EQ(uncompressed.get(natural_accessor.element<Y, X, X>()), 1.);
+    EXPECT_DOUBLE_EQ(uncompressed.get(natural_accessor.element<Y, X, Y>()), 3.);
+    EXPECT_DOUBLE_EQ(uncompressed.get(natural_accessor.element<Y, X, Z>()), 4.);
+    EXPECT_DOUBLE_EQ(uncompressed.get(natural_accessor.element<Y, Y, X>()), 3.);
+    EXPECT_DOUBLE_EQ(uncompressed.get(natural_accessor.element<Y, Y, Y>()), 6.);
+    EXPECT_DOUBLE_EQ(uncompressed.get(natural_accessor.element<Y, Y, Z>()), 7.);
+    EXPECT_DOUBLE_EQ(uncompressed.get(natural_accessor.element<Y, Z, X>()), 4.);
+    EXPECT_DOUBLE_EQ(uncompressed.get(natural_accessor.element<Y, Z, Y>()), 7.);
+    EXPECT_DOUBLE_EQ(uncompressed.get(natural_accessor.element<Y, Z, Z>()), 8.);
+    EXPECT_DOUBLE_EQ(uncompressed.get(natural_accessor.element<Z, X, X>()), 2.);
+    EXPECT_DOUBLE_EQ(uncompressed.get(natural_accessor.element<Z, X, Y>()), 4.);
+    EXPECT_DOUBLE_EQ(uncompressed.get(natural_accessor.element<Z, X, Z>()), 5.);
+    EXPECT_DOUBLE_EQ(uncompressed.get(natural_accessor.element<Z, Y, X>()), 4.);
+    EXPECT_DOUBLE_EQ(uncompressed.get(natural_accessor.element<Z, Y, Y>()), 7.);
+    EXPECT_DOUBLE_EQ(uncompressed.get(natural_accessor.element<Z, Y, Z>()), 8.);
+    EXPECT_DOUBLE_EQ(uncompressed.get(natural_accessor.element<Z, Z, X>()), 5.);
+    EXPECT_DOUBLE_EQ(uncompressed.get(natural_accessor.element<Z, Z, Y>()), 8.);
+    EXPECT_DOUBLE_EQ(uncompressed.get(natural_accessor.element<Z, Z, Z>()), 9.);
 }
 
 TEST(TensorProd, SimpleContractionRank3xRank2)


### PR DESCRIPTION
- Fixes
- `u()` and `v()` getters in YoungTableau.
- `compress` and `uncompress` functions associated to Young tableau tensors (perform `u*uncompressed `or `compressed*v`).
- Test compressing and uncompressing a natural symmetric rank-3 tensor.