### PR TITLE
First implementation of tensor product between a Young tableau-indexed tensor and a dense tensor

### DIFF
--- a/.devnote
+++ b/.devnote
@@ -58,3 +58,4 @@ using projector_index_t = ProjectorIndex<
 - IsTensorIndex::value has to be set to false
 - rename mem_id
 - sil::tensor::detail::Access implementation is not properly implemented
+- specialize tensor_prod using concepts (ie. redirect to natural_tensor_prod if NaturalTensorIndex)

--- a/.devnote
+++ b/.devnote
@@ -1,6 +1,8 @@
 ----- This file contains personal notes to keep track of ideas, TODO or previous chunks of code which has been removed but could be useful in different context -----
 ----- Not supposed to be read by anyone other than me -----
 
+cmake -DCMAKE_CXX_COMPILER=clang++-19 -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="-Wfatal-errors" ..
+
 // Extract Elem from a row of YoungTableauSeq at index J
 template <std::size_t J, std::size_t Id, class Row>
 struct ExtractElem;

--- a/src/tensor/antisymmetric_tensor.hpp
+++ b/src/tensor/antisymmetric_tensor.hpp
@@ -17,6 +17,16 @@ namespace tensor {
 template <class... TensorIndex>
 struct AntisymmetricTensorIndex
 {
+    using subindexes_domain_t = ddc::DiscreteDomain<TensorIndex...>;
+
+    static constexpr subindexes_domain_t subindexes_domain()
+    {
+        return ddc::DiscreteDomain<TensorIndex...>(
+                ddc::DiscreteElement<TensorIndex...>(ddc::DiscreteElement<TensorIndex>(0)...),
+                ddc::DiscreteVector<TensorIndex...>(
+                        ddc::DiscreteVector<TensorIndex>(TensorIndex::size())...));
+    }
+
     static constexpr std::size_t rank()
     {
         return (TensorIndex::rank() + ...);

--- a/src/tensor/diagonal_tensor.hpp
+++ b/src/tensor/diagonal_tensor.hpp
@@ -15,6 +15,16 @@ namespace tensor {
 template <class... TensorIndex>
 struct DiagonalTensorIndex
 {
+    using subindexes_domain_t = ddc::DiscreteDomain<TensorIndex...>;
+
+    static constexpr subindexes_domain_t subindexes_domain()
+    {
+        return ddc::DiscreteDomain<TensorIndex...>(
+                ddc::DiscreteElement<TensorIndex...>(ddc::DiscreteElement<TensorIndex>(0)...),
+                ddc::DiscreteVector<TensorIndex...>(
+                        ddc::DiscreteVector<TensorIndex>(TensorIndex::size())...));
+    }
+
     static constexpr std::size_t rank()
     {
         return (TensorIndex::rank() + ...);

--- a/src/tensor/full_tensor.hpp
+++ b/src/tensor/full_tensor.hpp
@@ -16,6 +16,16 @@ namespace tensor {
 template <class... TensorIndex>
 struct FullTensorIndex
 {
+    using subindexes_domain_t = ddc::DiscreteDomain<TensorIndex...>;
+
+    static constexpr subindexes_domain_t subindexes_domain()
+    {
+        return ddc::DiscreteDomain<TensorIndex...>(
+                ddc::DiscreteElement<TensorIndex...>(ddc::DiscreteElement<TensorIndex>(0)...),
+                ddc::DiscreteVector<TensorIndex...>(
+                        ddc::DiscreteVector<TensorIndex>(TensorIndex::size())...));
+    }
+
     static constexpr std::size_t rank()
     {
         return (TensorIndex::rank() + ...);

--- a/src/tensor/identity_tensor.hpp
+++ b/src/tensor/identity_tensor.hpp
@@ -15,6 +15,16 @@ namespace tensor {
 template <class... TensorIndex>
 struct IdentityTensorIndex
 {
+    using subindexes_domain_t = ddc::DiscreteDomain<TensorIndex...>;
+
+    static constexpr subindexes_domain_t subindexes_domain()
+    {
+        return ddc::DiscreteDomain<TensorIndex...>(
+                ddc::DiscreteElement<TensorIndex...>(ddc::DiscreteElement<TensorIndex>(0)...),
+                ddc::DiscreteVector<TensorIndex...>(
+                        ddc::DiscreteVector<TensorIndex>(TensorIndex::size())...));
+    }
+
     static constexpr std::size_t rank()
     {
         return (TensorIndex::rank() + ...);

--- a/src/tensor/symmetric_tensor.hpp
+++ b/src/tensor/symmetric_tensor.hpp
@@ -17,6 +17,16 @@ namespace tensor {
 template <class... TensorIndex>
 struct SymmetricTensorIndex
 {
+    using subindexes_domain_t = ddc::DiscreteDomain<TensorIndex...>;
+
+    static constexpr subindexes_domain_t subindexes_domain()
+    {
+        return ddc::DiscreteDomain<TensorIndex...>(
+                ddc::DiscreteElement<TensorIndex...>(ddc::DiscreteElement<TensorIndex>(0)...),
+                ddc::DiscreteVector<TensorIndex...>(
+                        ddc::DiscreteVector<TensorIndex>(TensorIndex::size())...));
+    }
+
     static constexpr std::size_t rank()
     {
         return (TensorIndex::rank() + ...);

--- a/src/tensor/tensor_impl.hpp
+++ b/src/tensor/tensor_impl.hpp
@@ -515,6 +515,127 @@ tensor_sum(
 
 namespace detail {
 
+// Domain of a tensor result of product between two tensors
+template <class Dom1, class Dom2>
+struct NaturalTensorProdDomain;
+
+template <class... DDim1, class... DDim2>
+struct NaturalTensorProdDomain<ddc::DiscreteDomain<DDim1...>, ddc::DiscreteDomain<DDim2...>>
+{
+    using type = ddc::detail::convert_type_seq_to_discrete_domain_t<ddc::type_seq_merge_t<
+            ddc::type_seq_remove_t<ddc::detail::TypeSeq<DDim1...>, ddc::detail::TypeSeq<DDim2...>>,
+            ddc::type_seq_remove_t<
+                    ddc::detail::TypeSeq<DDim2...>,
+                    ddc::detail::TypeSeq<DDim1...>>>>;
+};
+
+} // namespace detail
+
+template <class Dom1, class Dom2>
+using natural_tensor_prod_domain_t = detail::NaturalTensorProdDomain<Dom1, Dom2>::type;
+
+template <class Tensor1, class Tensor2>
+natural_tensor_prod_domain_t<
+        typename Tensor1::discrete_domain_type,
+        typename Tensor2::discrete_domain_type>
+natural_tensor_prod_domain(Tensor1 tensor1, Tensor2 tensor2)
+{
+    return natural_tensor_prod_domain_t<
+            typename Tensor1::discrete_domain_type,
+            typename Tensor2::discrete_domain_type>(tensor1.domain(), tensor2.domain());
+}
+
+namespace detail {
+
+// Product between two tensors naturally indexed.
+template <class HeadDDim1TypeSeq, class ContractDDimTypeSeq, class TailDDim2TypeSeq>
+struct NaturalTensorProd;
+
+template <class... HeadDDim1, class... ContractDDim, class... TailDDim2>
+struct NaturalTensorProd<
+        ddc::detail::TypeSeq<HeadDDim1...>,
+        ddc::detail::TypeSeq<ContractDDim...>,
+        ddc::detail::TypeSeq<TailDDim2...>>
+{
+    template <class ElementType, class LayoutStridedPolicy, class MemorySpace>
+    static Tensor<
+            ElementType,
+            ddc::DiscreteDomain<HeadDDim1..., TailDDim2...>,
+            LayoutStridedPolicy,
+            MemorySpace>
+    run(Tensor<ElementType,
+               ddc::DiscreteDomain<HeadDDim1..., TailDDim2...>,
+               std::experimental::layout_right,
+               Kokkos::DefaultHostExecutionSpace::memory_space> prod_tensor,
+        Tensor<ElementType,
+               ddc::DiscreteDomain<HeadDDim1..., ContractDDim...>,
+               LayoutStridedPolicy,
+               MemorySpace> tensor1,
+        Tensor<ElementType,
+               ddc::DiscreteDomain<ContractDDim..., TailDDim2...>,
+               LayoutStridedPolicy,
+               MemorySpace> tensor2)
+    {
+        ddc::for_each(
+                prod_tensor.domain(),
+                [&](ddc::DiscreteElement<HeadDDim1..., TailDDim2...> elem) {
+                    prod_tensor(elem) = ddc::transform_reduce(
+                            tensor1.template domain<ContractDDim...>(),
+                            0.,
+                            ddc::reducer::sum<ElementType>(),
+                            [&](ddc::DiscreteElement<ContractDDim...> contract_elem) {
+                                return tensor1(ddc::select<HeadDDim1...>(elem), contract_elem)
+                                       * tensor2(ddc::select<TailDDim2...>(elem), contract_elem);
+                            });
+                });
+        return prod_tensor;
+    }
+};
+
+} // namespace detail
+
+template <
+        class... ProdDDim,
+        class... DDim1,
+        class... DDim2,
+        class ElementType,
+        class LayoutStridedPolicy,
+        class MemorySpace>
+Tensor<ElementType,
+       ddc::DiscreteDomain<ProdDDim...>,
+       std::experimental::layout_right,
+       Kokkos::DefaultHostExecutionSpace::memory_space>
+natural_tensor_prod(
+        Tensor<ElementType,
+               ddc::DiscreteDomain<ProdDDim...>,
+               std::experimental::layout_right,
+               Kokkos::DefaultHostExecutionSpace::memory_space> prod_tensor,
+        Tensor<ElementType, ddc::DiscreteDomain<DDim1...>, LayoutStridedPolicy, MemorySpace>
+                tensor1,
+        Tensor<ElementType, ddc::DiscreteDomain<DDim2...>, LayoutStridedPolicy, MemorySpace>
+                tensor2)
+{
+    static_assert(std::is_same_v<
+                  ddc::type_seq_remove_t<
+                          ddc::detail::TypeSeq<DDim1...>,
+                          ddc::detail::TypeSeq<ProdDDim...>>,
+                  ddc::type_seq_remove_t<
+                          ddc::detail::TypeSeq<DDim2...>,
+                          ddc::detail::TypeSeq<ProdDDim...>>>);
+    return detail::NaturalTensorProd<
+            ddc::type_seq_remove_t<
+                    ddc::detail::TypeSeq<ProdDDim...>,
+                    ddc::detail::TypeSeq<DDim2...>>,
+            ddc::type_seq_remove_t<
+                    ddc::detail::TypeSeq<DDim1...>,
+                    ddc::detail::TypeSeq<ProdDDim...>>,
+            ddc::type_seq_remove_t<
+                    ddc::detail::TypeSeq<ProdDDim...>,
+                    ddc::detail::TypeSeq<DDim1...>>>::run(prod_tensor, tensor1, tensor2);
+}
+
+namespace detail {
+
 template <class HeadDom, class InterestDom, class TailDom>
 struct PrintTensor;
 

--- a/src/tensor/tensor_prod.hpp
+++ b/src/tensor/tensor_prod.hpp
@@ -5,16 +5,20 @@
 
 #include <ddc/ddc.hpp>
 
+#include "young_tableau_tensor.hpp"
+
 namespace sil {
 
 namespace tensor {
 
+namespace detail {
+/*
 // Domain of a tensor result of product between two tensors
 template <class Dom1, class Dom2>
-struct TensorProdDomain;
+struct NaturalTensorProdDomain;
 
 template <class... DDim1, class... DDim2>
-struct TensorProdDomain<ddc::DiscreteDomain<DDim1...>, ddc::DiscreteDomain<DDim2...>>
+struct NaturalTensorProdDomain<ddc::DiscreteDomain<DDim1...>, ddc::DiscreteDomain<DDim2...>>
 {
     using type = ddc::detail::convert_type_seq_to_discrete_domain_t<ddc::type_seq_merge_t<
             ddc::type_seq_remove_t<ddc::detail::TypeSeq<DDim1...>, ddc::detail::TypeSeq<DDim2...>>,
@@ -23,24 +27,62 @@ struct TensorProdDomain<ddc::DiscreteDomain<DDim1...>, ddc::DiscreteDomain<DDim2
                     ddc::detail::TypeSeq<DDim1...>>>>;
 };
 
+} // namespace detail
+
 template <class Dom1, class Dom2>
-using tensor_prod_domain_t = TensorProdDomain<Dom1, Dom2>::type;
+using natural_tensor_prod_domain_t = detail::NaturalTensorProdDomain<Dom1, Dom2>::type;
 
 template <class Tensor1, class Tensor2>
-tensor_prod_domain_t<typename Tensor1::discrete_domain_type, typename Tensor2::discrete_domain_type>
-tensor_prod_domain(Tensor1 tensor1, Tensor2 tensor2)
+natural_tensor_prod_domain_t<
+        typename Tensor1::discrete_domain_type,
+        typename Tensor2::discrete_domain_type>
+natural_tensor_prod_domain(Tensor1 tensor1, Tensor2 tensor2)
 {
-    return sil::tensor::tensor_prod_domain_t<
+    return natural_tensor_prod_domain_t<
             typename Tensor1::discrete_domain_type,
             typename Tensor2::discrete_domain_type>(tensor1.domain(), tensor2.domain());
 }
 
-// Product between two tensors. Only natural indexing supported atm.
-template <class HeadDDim1TypeSeq, class ContractDDimTypeSeq, class TailDDim2TypeSeq>
+// Domain of a tensor result of product between two tensors
+template <class T>
+struct DomainFromSubindexes;
+
+template <class... Subindex>
+struct DomainFromSubindexes<ddc::DiscreteDomain<DDim1...>, ddc::DiscreteDomain<DDim2...>>
+{
+    using type = ddc::detail::convert_type_seq_to_discrete_domain_t<ddc::type_seq_merge_t<
+            ddc::type_seq_remove_t<ddc::detail::TypeSeq<DDim1...>, ddc::detail::TypeSeq<DDim2...>>,
+            ddc::type_seq_remove_t<
+                    ddc::detail::TypeSeq<DDim2...>,
+                    ddc::detail::TypeSeq<DDim1...>>>>;
+};
+
+} // namespace detail
+*/
+
+template <class Dom1, class Dom2>
+using natural_tensor_prod_domain_t = detail::NaturalTensorProdDomain<Dom1, Dom2>::type;
+
+template <class Tensor1, class Tensor2>
+natural_tensor_prod_domain_t<
+        typename Tensor1::discrete_domain_type,
+        typename Tensor2::discrete_domain_type>
+natural_tensor_prod_domain(Tensor1 tensor1, Tensor2 tensor2)
+{
+    return natural_tensor_prod_domain_t<
+            typename Tensor1::discrete_domain_type,
+            typename Tensor2::discrete_domain_type>(tensor1.domain(), tensor2.domain());
+}
+template <
+        class YoungTableauIndex,
+        class HeadDDim1TypeSeq,
+        class ContractDDimTypeSeq,
+        class TailDDim2TypeSeq>
 struct TensorProd;
 
-template <class... HeadDDim1, class... ContractDDim, class... TailDDim2>
+template <class YoungTableau, class... HeadDDim1, class... ContractDDim, class... TailDDim2>
 struct TensorProd<
+        YoungTableau,
         ddc::detail::TypeSeq<HeadDDim1...>,
         ddc::detail::TypeSeq<ContractDDim...>,
         ddc::detail::TypeSeq<TailDDim2...>>
@@ -56,7 +98,10 @@ struct TensorProd<
                std::experimental::layout_right,
                Kokkos::DefaultHostExecutionSpace::memory_space> prod_tensor,
         Tensor<ElementType,
-               ddc::DiscreteDomain<HeadDDim1..., ContractDDim...>,
+               ddc::DiscreteDomain<YoungTableauIndex typename sil::tensor::YoungTableauTensorIndex<
+                       YoungTableau,
+                       HeadDDim1...,
+                       ContractDDim...>>,
                LayoutStridedPolicy,
                MemorySpace> tensor1,
         Tensor<ElementType,
@@ -64,21 +109,25 @@ struct TensorProd<
                LayoutStridedPolicy,
                MemorySpace> tensor2)
     {
-        ddc::for_each(
-                prod_tensor.domain(),
-                [&](ddc::DiscreteElement<HeadDDim1..., TailDDim2...> elem) {
-                    prod_tensor(elem) = ddc::transform_reduce(
-                            tensor1.template domain<ContractDDim...>(),
-                            0.,
-                            ddc::reducer::sum<ElementType>(),
-                            [&](ddc::DiscreteElement<ContractDDim...> contract_elem) {
-                                return tensor1(ddc::select<HeadDDim1...>(elem), contract_elem)
-                                       * tensor2(ddc::select<TailDDim2...>(elem), contract_elem);
-                            });
-                });
-        return prod_tensor;
+        /*
+    typename YoungTableauTensorIndex<DDim1...>::young_tableau young_tableau;
+    sil::csr::Csr u = young_tableau.template u<YoungTableauIndex, DDim2...>(tensor2.domain());
+*/
+        ddc::Chunk uncompressed_tensor1_alloc(tensor1.domain(), ddc::HostAllocator<double>());
+        sil::tensor::Tensor<
+                double,
+                ddc::DiscreteDomain<HeadDDim1..., ContractDDim...>,
+                std::experimental::layout_right,
+                Kokkos::DefaultHostExecutionSpace::memory_space>
+                uncompressed_tensor1(uncompressed_tensor1_alloc);
+
+        sil::tensor::uncompress(uncompressed_tensor1, tensor1);
+
+        return natural_tensor_prod(prod_tensor, uncompressed_tensor1, tensor1);
     }
 };
+
+} // namespace detail
 
 template <
         class... ProdDDim,
@@ -86,7 +135,8 @@ template <
         class... DDim2,
         class ElementType,
         class LayoutStridedPolicy,
-        class MemorySpace>
+        class MemorySpace,
+        class YoungTableau>
 Tensor<ElementType,
        ddc::DiscreteDomain<ProdDDim...>,
        std::experimental::layout_right,
@@ -96,8 +146,10 @@ tensor_prod(
                ddc::DiscreteDomain<ProdDDim...>,
                std::experimental::layout_right,
                Kokkos::DefaultHostExecutionSpace::memory_space> prod_tensor,
-        Tensor<ElementType, ddc::DiscreteDomain<DDim1...>, LayoutStridedPolicy, MemorySpace>
-                tensor1,
+        Tensor<ElementType,
+               ddc::DiscreteDomain<YoungTableauTensorIndex<YoungTableau, DDim1...>>,
+               LayoutStridedPolicy,
+               MemorySpace> tensor1,
         Tensor<ElementType, ddc::DiscreteDomain<DDim2...>, LayoutStridedPolicy, MemorySpace>
                 tensor2)
 {
@@ -108,7 +160,8 @@ tensor_prod(
                   ddc::type_seq_remove_t<
                           ddc::detail::TypeSeq<DDim2...>,
                           ddc::detail::TypeSeq<ProdDDim...>>>);
-    return TensorProd<
+    return detail::TensorProd<
+            YoungTableau,
             ddc::type_seq_remove_t<
                     ddc::detail::TypeSeq<ProdDDim...>,
                     ddc::detail::TypeSeq<DDim2...>>,

--- a/src/tensor/tensor_prod.hpp
+++ b/src/tensor/tensor_prod.hpp
@@ -12,67 +12,6 @@ namespace sil {
 namespace tensor {
 
 namespace detail {
-/*
-// Domain of a tensor result of product between two tensors
-template <class Dom1, class Dom2>
-struct NaturalTensorProdDomain;
-
-template <class... DDim1, class... DDim2>
-struct NaturalTensorProdDomain<ddc::DiscreteDomain<DDim1...>, ddc::DiscreteDomain<DDim2...>>
-{
-    using type = ddc::detail::convert_type_seq_to_discrete_domain_t<ddc::type_seq_merge_t<
-            ddc::type_seq_remove_t<ddc::detail::TypeSeq<DDim1...>, ddc::detail::TypeSeq<DDim2...>>,
-            ddc::type_seq_remove_t<
-                    ddc::detail::TypeSeq<DDim2...>,
-                    ddc::detail::TypeSeq<DDim1...>>>>;
-};
-
-} // namespace detail
-
-template <class Dom1, class Dom2>
-using natural_tensor_prod_domain_t = detail::NaturalTensorProdDomain<Dom1, Dom2>::type;
-
-template <class Tensor1, class Tensor2>
-natural_tensor_prod_domain_t<
-        typename Tensor1::discrete_domain_type,
-        typename Tensor2::discrete_domain_type>
-natural_tensor_prod_domain(Tensor1 tensor1, Tensor2 tensor2)
-{
-    return natural_tensor_prod_domain_t<
-            typename Tensor1::discrete_domain_type,
-            typename Tensor2::discrete_domain_type>(tensor1.domain(), tensor2.domain());
-}
-
-// Domain of a tensor result of product between two tensors
-template <class T>
-struct DomainFromSubindexes;
-
-template <class... Subindex>
-struct DomainFromSubindexes<ddc::DiscreteDomain<DDim1...>, ddc::DiscreteDomain<DDim2...>>
-{
-    using type = ddc::detail::convert_type_seq_to_discrete_domain_t<ddc::type_seq_merge_t<
-            ddc::type_seq_remove_t<ddc::detail::TypeSeq<DDim1...>, ddc::detail::TypeSeq<DDim2...>>,
-            ddc::type_seq_remove_t<
-                    ddc::detail::TypeSeq<DDim2...>,
-                    ddc::detail::TypeSeq<DDim1...>>>>;
-};
-
-} // namespace detail
-
-template <class Dom1, class Dom2>
-using natural_tensor_prod_domain_t = detail::NaturalTensorProdDomain<Dom1, Dom2>::type;
-
-template <class Tensor1, class Tensor2>
-natural_tensor_prod_domain_t<
-        typename Tensor1::discrete_domain_type,
-        typename Tensor2::discrete_domain_type>
-natural_tensor_prod_domain(Tensor1 tensor1, Tensor2 tensor2)
-{
-    return natural_tensor_prod_domain_t<
-            typename Tensor1::discrete_domain_type,
-            typename Tensor2::discrete_domain_type>(tensor1.domain(), tensor2.domain());
-}
-*/
 
 template <class Index>
 struct SubindexesDomain;

--- a/src/tensor/young_tableau_tensor.hpp
+++ b/src/tensor/young_tableau_tensor.hpp
@@ -6,7 +6,7 @@
 #include <ddc/ddc.hpp>
 
 #include "csr.hpp"
-#include "full_tensor.hpp"
+#include "stride.hpp"
 #include "tensor.hpp"
 #include "young_tableau.hpp"
 

--- a/src/tensor/young_tableau_tensor.hpp
+++ b/src/tensor/young_tableau_tensor.hpp
@@ -20,6 +20,16 @@ struct YoungTableauTensorIndex
 {
     using young_tableau = YoungTableau;
 
+    using subindexes_domain_t = ddc::DiscreteDomain<TensorIndex...>;
+
+    static constexpr subindexes_domain_t subindexes_domain()
+    {
+        return ddc::DiscreteDomain<TensorIndex...>(
+                ddc::DiscreteElement<TensorIndex...>(ddc::DiscreteElement<TensorIndex>(0)...),
+                ddc::DiscreteVector<TensorIndex...>(
+                        ddc::DiscreteVector<TensorIndex>(TensorIndex::size())...));
+    }
+
     static constexpr std::size_t rank()
     {
         return (TensorIndex::rank() + ...);

--- a/src/young_tableau/young_tableau.hpp
+++ b/src/young_tableau/young_tableau.hpp
@@ -1059,7 +1059,6 @@ template <class BasisId, class... Id>
 constexpr sil::csr::Csr<YoungTableau<Dimension, TableauSeq>::n_nonzeros_in_irrep(), BasisId, Id...>
 YoungTableau<Dimension, TableauSeq>::u(ddc::DiscreteDomain<Id...> restricted_domain)
 {
-    // static_assert(n_nonzeros_in_irrep() != 0);
     if constexpr (n_nonzeros_in_irrep() != 0) {
         ddc::DiscreteDomain<BasisId, Id...>
                 domain(ddc::DiscreteDomain<BasisId>(
@@ -1092,7 +1091,6 @@ template <class BasisId, class... Id>
 constexpr sil::csr::Csr<YoungTableau<Dimension, TableauSeq>::n_nonzeros_in_irrep(), BasisId, Id...>
 YoungTableau<Dimension, TableauSeq>::v(ddc::DiscreteDomain<Id...> restricted_domain)
 {
-    // static_assert(n_nonzeros_in_irrep() != 0);
     if constexpr (n_nonzeros_in_irrep() != 0) {
         ddc::DiscreteDomain<BasisId, Id...>
                 domain(ddc::DiscreteDomain<BasisId>(

--- a/tests/tensor/CMakeLists.txt
+++ b/tests/tensor/CMakeLists.txt
@@ -5,22 +5,22 @@ include(GoogleTest)
 
 add_executable(unit_tests_tensor tensor.cpp ../main.cpp)
 
-target_link_libraries(unit_tests_tensor 
+target_link_libraries(unit_tests_tensor
     PUBLIC
         GTest::gtest
         DDC::DDC
         sil::tensor
-) 
+)
 
 gtest_discover_tests(unit_tests_tensor DISCOVERY_MODE PRE_TEST)
 
 add_executable(unit_tests_tensor_prod tensor_prod.cpp ../main.cpp)
 
-target_link_libraries(unit_tests_tensor_prod 
+target_link_libraries(unit_tests_tensor_prod
     PUBLIC
         GTest::gtest
         DDC::DDC
         sil::tensor
-) 
+)
 
 gtest_discover_tests(unit_tests_tensor_prod DISCOVERY_MODE PRE_TEST)

--- a/tests/tensor/CMakeLists.txt
+++ b/tests/tensor/CMakeLists.txt
@@ -13,3 +13,14 @@ target_link_libraries(unit_tests_tensor
 ) 
 
 gtest_discover_tests(unit_tests_tensor DISCOVERY_MODE PRE_TEST)
+
+add_executable(unit_tests_tensor_prod tensor_prod.cpp ../main.cpp)
+
+target_link_libraries(unit_tests_tensor_prod 
+    PUBLIC
+        GTest::gtest
+        DDC::DDC
+        sil::tensor
+) 
+
+gtest_discover_tests(unit_tests_tensor_prod DISCOVERY_MODE PRE_TEST)

--- a/tests/tensor/tensor_prod.cpp
+++ b/tests/tensor/tensor_prod.cpp
@@ -33,6 +33,10 @@ struct Gamma : sil::tensor::TensorNaturalIndex<X, Y, Z>
 {
 };
 
+struct Delta : sil::tensor::TensorNaturalIndex<X, Y, Z>
+{
+};
+
 TEST(TensorProd, SimpleContractionRank3xRank2)
 {
     sil::tensor::TensorAccessor<Alpha, Beta, Gamma> tensor_accessor1;
@@ -105,7 +109,7 @@ TEST(TensorProd, SimpleContractionRank3xRank2)
             Kokkos::DefaultHostExecutionSpace::memory_space>
             prod_tensor(prod_tensor_alloc);
 
-    sil::tensor::tensor_prod(prod_tensor, tensor1, tensor2);
+    sil::tensor::natural_tensor_prod(prod_tensor, tensor1, tensor2);
 
     EXPECT_EQ(prod_tensor.get(prod_tensor_accessor.element<X, X, X>()), 15.);
     EXPECT_EQ(prod_tensor.get(prod_tensor_accessor.element<X, X, Y>()), 18.);
@@ -226,7 +230,137 @@ TEST(TensorProd, DoubleContractionRank3xRank3)
             Kokkos::DefaultHostExecutionSpace::memory_space>
             prod_tensor(prod_tensor_alloc);
 
-    sil::tensor::tensor_prod(prod_tensor, tensor1, tensor2);
+    sil::tensor::natural_tensor_prod(prod_tensor, tensor1, tensor2);
+
+    EXPECT_EQ(prod_tensor.get(prod_tensor_accessor.element<X, X>()), 612.);
+    EXPECT_EQ(prod_tensor.get(prod_tensor_accessor.element<X, Y>()), 648.);
+    EXPECT_EQ(prod_tensor.get(prod_tensor_accessor.element<X, Z>()), 684.);
+    EXPECT_EQ(prod_tensor.get(prod_tensor_accessor.element<Y, X>()), 1584.);
+    EXPECT_EQ(prod_tensor.get(prod_tensor_accessor.element<Y, Y>()), 1701.);
+    EXPECT_EQ(prod_tensor.get(prod_tensor_accessor.element<Y, Z>()), 1818.);
+    EXPECT_EQ(prod_tensor.get(prod_tensor_accessor.element<Z, X>()), 2556.);
+    EXPECT_EQ(prod_tensor.get(prod_tensor_accessor.element<Z, Y>()), 2754.);
+    EXPECT_EQ(prod_tensor.get(prod_tensor_accessor.element<Z, Z>()), 2952.);
+}
+
+struct YoungTableauIndex
+    : sil::tensor::YoungTableauTensorIndex<
+              sil::young_tableau::YoungTableau<
+                      3,
+                      sil::young_tableau::YoungTableauSeq<std::index_sequence<1, 2, 3>>>,
+              Alpha,
+              Beta,
+              Gamma>
+{
+};
+
+TEST(TensorProd, DoubleContractionYoungIndexedxNaturalIndex)
+{
+    sil::tensor::TensorAccessor<Alpha, Beta, Gamma> natural_accessor;
+    ddc::DiscreteDomain<Alpha, Beta, Gamma> natural_dom = natural_accessor.mem_domain();
+    ddc::Chunk natural_alloc(natural_dom, ddc::HostAllocator<double>());
+    sil::tensor::Tensor<
+            double,
+            ddc::DiscreteDomain<Alpha, Beta, Gamma>,
+            std::experimental::layout_right,
+            Kokkos::DefaultHostExecutionSpace::memory_space>
+            natural(natural_alloc);
+
+    natural(natural_accessor.element<X, X, X>()) = 0.;
+    natural(natural_accessor.element<X, X, Y>()) = 1.;
+    natural(natural_accessor.element<X, X, Z>()) = 2.;
+    natural(natural_accessor.element<X, Y, X>()) = 1.;
+    natural(natural_accessor.element<X, Y, Y>()) = 3.;
+    natural(natural_accessor.element<X, Y, Z>()) = 4.;
+    natural(natural_accessor.element<X, Z, X>()) = 2.;
+    natural(natural_accessor.element<X, Z, Y>()) = 4.;
+    natural(natural_accessor.element<X, Z, Z>()) = 5.;
+    natural(natural_accessor.element<Y, X, X>()) = 1.;
+    natural(natural_accessor.element<Y, X, Y>()) = 3.;
+    natural(natural_accessor.element<Y, X, Z>()) = 4.;
+    natural(natural_accessor.element<Y, Y, X>()) = 3.;
+    natural(natural_accessor.element<Y, Y, Y>()) = 6.;
+    natural(natural_accessor.element<Y, Y, Z>()) = 7.;
+    natural(natural_accessor.element<Y, Z, X>()) = 4.;
+    natural(natural_accessor.element<Y, Z, Y>()) = 7.;
+    natural(natural_accessor.element<Y, Z, Z>()) = 8.;
+    natural(natural_accessor.element<Z, X, X>()) = 2.;
+    natural(natural_accessor.element<Z, X, Y>()) = 4.;
+    natural(natural_accessor.element<Z, X, Z>()) = 5.;
+    natural(natural_accessor.element<Z, Y, X>()) = 4.;
+    natural(natural_accessor.element<Z, Y, Y>()) = 7.;
+    natural(natural_accessor.element<Z, Y, Z>()) = 8.;
+    natural(natural_accessor.element<Z, Z, X>()) = 5.;
+    natural(natural_accessor.element<Z, Z, Y>()) = 8.;
+    natural(natural_accessor.element<Z, Z, Z>()) = 9.;
+
+    sil::tensor::TensorAccessor<YoungTableauIndex> tensor_accessor1;
+    ddc::DiscreteDomain<YoungTableauIndex> tensor1_dom = tensor_accessor1.mem_domain();
+    ddc::Chunk tensor1_alloc(tensor1_dom, ddc::HostAllocator<double>());
+    sil::tensor::Tensor<
+            double,
+            ddc::DiscreteDomain<YoungTableauIndex>,
+            std::experimental::layout_right,
+            Kokkos::DefaultHostExecutionSpace::memory_space>
+            tensor1(tensor1_alloc);
+
+    sil::tensor::compress(tensor1, natural);
+
+    sil::tensor::TensorAccessor<Beta, Gamma, Delta> tensor_accessor2;
+    ddc::DiscreteDomain<Beta, Gamma, Delta> tensor2_dom = tensor_accessor2.mem_domain();
+    ddc::Chunk tensor2_alloc(tensor2_dom, ddc::HostAllocator<double>());
+    sil::tensor::Tensor<
+            double,
+            ddc::DiscreteDomain<Beta, Gamma, Delta>,
+            std::experimental::layout_right,
+            Kokkos::DefaultHostExecutionSpace::memory_space>
+            tensor2(tensor2_alloc);
+
+    tensor2(tensor_accessor2.element<X, X, X>()) = 0.;
+    tensor2(tensor_accessor2.element<X, X, Y>()) = 1.;
+    tensor2(tensor_accessor2.element<X, X, Z>()) = 2.;
+    tensor2(tensor_accessor2.element<X, Y, X>()) = 3.;
+    tensor2(tensor_accessor2.element<X, Y, Y>()) = 4.;
+    tensor2(tensor_accessor2.element<X, Y, Z>()) = 5.;
+    tensor2(tensor_accessor2.element<X, Z, X>()) = 6.;
+    tensor2(tensor_accessor2.element<X, Z, Y>()) = 7.;
+    tensor2(tensor_accessor2.element<X, Z, Z>()) = 8.;
+    tensor2(tensor_accessor2.element<Y, X, X>()) = 9.;
+    tensor2(tensor_accessor2.element<Y, X, Y>()) = 10.;
+    tensor2(tensor_accessor2.element<Y, X, Z>()) = 11.;
+    tensor2(tensor_accessor2.element<Y, Y, X>()) = 12.;
+    tensor2(tensor_accessor2.element<Y, Y, Y>()) = 13.;
+    tensor2(tensor_accessor2.element<Y, Y, Z>()) = 14.;
+    tensor2(tensor_accessor2.element<Y, Z, X>()) = 15.;
+    tensor2(tensor_accessor2.element<Y, Z, Y>()) = 16.;
+    tensor2(tensor_accessor2.element<Y, Z, Z>()) = 17.;
+    tensor2(tensor_accessor2.element<Z, X, X>()) = 18.;
+    tensor2(tensor_accessor2.element<Z, X, Y>()) = 19.;
+    tensor2(tensor_accessor2.element<Z, X, Z>()) = 20.;
+    tensor2(tensor_accessor2.element<Z, Y, X>()) = 21.;
+    tensor2(tensor_accessor2.element<Z, Y, Y>()) = 22.;
+    tensor2(tensor_accessor2.element<Z, Y, Z>()) = 23.;
+    tensor2(tensor_accessor2.element<Z, Z, X>()) = 24.;
+    tensor2(tensor_accessor2.element<Z, Z, Y>()) = 25.;
+    tensor2(tensor_accessor2.element<Z, Z, Z>()) = 26.;
+
+    sil::tensor::TensorAccessor<Alpha, Delta> prod_tensor_accessor;
+    ddc::DiscreteDomain<Alpha, Delta> prod_tensor_dom = prod_tensor_accessor.mem_domain();
+
+    ddc::Chunk prod_tensor_alloc(prod_tensor_dom, ddc::HostAllocator<double>());
+    sil::tensor::Tensor<
+            double,
+            ddc::DiscreteDomain<Alpha, Delta>,
+            std::experimental::layout_right,
+            Kokkos::DefaultHostExecutionSpace::memory_space>
+            prod_tensor(prod_tensor_alloc);
+
+    // sil::tensor::tensor_prod(prod_tensor, tensor1, tensor2);
+    sil::tensor::detail::TensorProd<
+            typename YoungTableauIndex::young_tableau,
+            ddc::detail::TypeSeq<Alpha>,
+            ddc::detail::TypeSeq<Beta, Gamma>,
+            ddc::detail::TypeSeq<Delta>>::run(prod_tensor, tensor1, tensor2);
 
     EXPECT_EQ(prod_tensor.get(prod_tensor_accessor.element<X, X>()), 612.);
     EXPECT_EQ(prod_tensor.get(prod_tensor_accessor.element<X, Y>()), 648.);

--- a/tests/tensor/tensor_prod.cpp
+++ b/tests/tensor/tensor_prod.cpp
@@ -355,20 +355,15 @@ TEST(TensorProd, DoubleContractionYoungIndexedxNaturalIndex)
             Kokkos::DefaultHostExecutionSpace::memory_space>
             prod_tensor(prod_tensor_alloc);
 
-    // sil::tensor::tensor_prod(prod_tensor, tensor1, tensor2);
-    sil::tensor::detail::TensorProd<
-            typename YoungTableauIndex::young_tableau,
-            ddc::detail::TypeSeq<Alpha>,
-            ddc::detail::TypeSeq<Beta, Gamma>,
-            ddc::detail::TypeSeq<Delta>>::run(prod_tensor, tensor1, tensor2);
+    sil::tensor::tensor_prod(prod_tensor, tensor1, tensor2);
 
-    EXPECT_EQ(prod_tensor.get(prod_tensor_accessor.element<X, X>()), 612.);
-    EXPECT_EQ(prod_tensor.get(prod_tensor_accessor.element<X, Y>()), 648.);
-    EXPECT_EQ(prod_tensor.get(prod_tensor_accessor.element<X, Z>()), 684.);
-    EXPECT_EQ(prod_tensor.get(prod_tensor_accessor.element<Y, X>()), 1584.);
-    EXPECT_EQ(prod_tensor.get(prod_tensor_accessor.element<Y, Y>()), 1701.);
-    EXPECT_EQ(prod_tensor.get(prod_tensor_accessor.element<Y, Z>()), 1818.);
-    EXPECT_EQ(prod_tensor.get(prod_tensor_accessor.element<Z, X>()), 2556.);
-    EXPECT_EQ(prod_tensor.get(prod_tensor_accessor.element<Z, Y>()), 2754.);
-    EXPECT_EQ(prod_tensor.get(prod_tensor_accessor.element<Z, Z>()), 2952.);
+    EXPECT_DOUBLE_EQ(prod_tensor.get(prod_tensor_accessor.element<X, X>()), 360.);
+    EXPECT_DOUBLE_EQ(prod_tensor.get(prod_tensor_accessor.element<X, Y>()), 382.);
+    EXPECT_DOUBLE_EQ(prod_tensor.get(prod_tensor_accessor.element<X, Z>()), 404.);
+    EXPECT_DOUBLE_EQ(prod_tensor.get(prod_tensor_accessor.element<Y, X>()), 648.);
+    EXPECT_DOUBLE_EQ(prod_tensor.get(prod_tensor_accessor.element<Y, Y>()), 691.);
+    EXPECT_DOUBLE_EQ(prod_tensor.get(prod_tensor_accessor.element<Y, Z>()), 734.);
+    EXPECT_DOUBLE_EQ(prod_tensor.get(prod_tensor_accessor.element<Z, X>()), 756.);
+    EXPECT_DOUBLE_EQ(prod_tensor.get(prod_tensor_accessor.element<Z, Y>()), 808.);
+    EXPECT_DOUBLE_EQ(prod_tensor.get(prod_tensor_accessor.element<Z, Z>()), 860.);
 }

--- a/tests/young_tableau/young_tableau.cpp
+++ b/tests/young_tableau/young_tableau.cpp
@@ -6,7 +6,7 @@
 #include <gtest/gtest.h>
 
 #include "tensor.hpp"
-#include "young_tableau.hpp"
+// #include "young_tableau.hpp"
 
 struct X
 {
@@ -85,19 +85,19 @@ TEST(YoungTableau, 1_2)
 
     auto [proj_alloc, proj] = young_tableau.projector<Mu, Nu>();
 
-    ddc::Chunk prod_alloc(tensor_prod_domain(proj, tensor), ddc::HostAllocator<double>());
+    ddc::Chunk prod_alloc(natural_tensor_prod_domain(proj, tensor), ddc::HostAllocator<double>());
     sil::tensor::Tensor<
             double,
-            sil::tensor::tensor_prod_domain_t<
+            sil::tensor::natural_tensor_prod_domain_t<
                     typename decltype(young_tableau)::projector_domain<Mu, Nu>,
                     ddc::DiscreteDomain<Mu, Nu>>,
             std::experimental::layout_right,
             Kokkos::DefaultHostExecutionSpace::memory_space>
             prod(prod_alloc);
 
-    sil::tensor::tensor_prod(prod, proj, tensor);
+    sil::tensor::natural_tensor_prod(prod, proj, tensor);
 
-    sil::tensor::tensor_accessor_for_domain_t<sil::tensor::tensor_prod_domain_t<
+    sil::tensor::tensor_accessor_for_domain_t<sil::tensor::natural_tensor_prod_domain_t<
             typename decltype(young_tableau)::projector_domain<Mu, Nu>,
             ddc::DiscreteDomain<Mu, Nu>>>
             tensor_accessor_prod;
@@ -159,19 +159,19 @@ TEST(YoungTableau, 1l2)
 
     auto [proj_alloc, proj] = young_tableau.projector<Mu, Nu>();
 
-    ddc::Chunk prod_alloc(tensor_prod_domain(proj, tensor), ddc::HostAllocator<double>());
+    ddc::Chunk prod_alloc(natural_tensor_prod_domain(proj, tensor), ddc::HostAllocator<double>());
     sil::tensor::Tensor<
             double,
-            sil::tensor::tensor_prod_domain_t<
+            sil::tensor::natural_tensor_prod_domain_t<
                     typename decltype(young_tableau)::projector_domain<Mu, Nu>,
                     ddc::DiscreteDomain<Mu, Nu>>,
             std::experimental::layout_right,
             Kokkos::DefaultHostExecutionSpace::memory_space>
             prod(prod_alloc);
 
-    sil::tensor::tensor_prod(prod, proj, tensor);
+    sil::tensor::natural_tensor_prod(prod, proj, tensor);
 
-    sil::tensor::tensor_accessor_for_domain_t<sil::tensor::tensor_prod_domain_t<
+    sil::tensor::tensor_accessor_for_domain_t<sil::tensor::natural_tensor_prod_domain_t<
             typename decltype(young_tableau)::projector_domain<Mu, Nu>,
             ddc::DiscreteDomain<Mu, Nu>>>
             tensor_accessor_prod;
@@ -247,19 +247,19 @@ TEST(YoungTableau, 1_2_3)
 
     auto [proj_alloc, proj] = young_tableau.projector<Alpha, Beta, Gamma>();
 
-    ddc::Chunk prod_alloc(tensor_prod_domain(proj, tensor), ddc::HostAllocator<double>());
+    ddc::Chunk prod_alloc(natural_tensor_prod_domain(proj, tensor), ddc::HostAllocator<double>());
     sil::tensor::Tensor<
             double,
-            sil::tensor::tensor_prod_domain_t<
+            sil::tensor::natural_tensor_prod_domain_t<
                     typename decltype(young_tableau)::projector_domain<Alpha, Beta, Gamma>,
                     ddc::DiscreteDomain<Alpha, Beta, Gamma>>,
             std::experimental::layout_right,
             Kokkos::DefaultHostExecutionSpace::memory_space>
             prod(prod_alloc);
 
-    sil::tensor::tensor_prod(prod, proj, tensor);
+    sil::tensor::natural_tensor_prod(prod, proj, tensor);
 
-    sil::tensor::tensor_accessor_for_domain_t<sil::tensor::tensor_prod_domain_t<
+    sil::tensor::tensor_accessor_for_domain_t<sil::tensor::natural_tensor_prod_domain_t<
             typename decltype(young_tableau)::projector_domain<Alpha, Beta, Gamma>,
             ddc::DiscreteDomain<Alpha, Beta, Gamma>>>
             tensor_accessor_prod;
@@ -364,19 +364,19 @@ TEST(YoungTableau, 1l2l3)
 
     auto [proj_alloc, proj] = young_tableau.projector<Alpha, Beta, Gamma>();
 
-    ddc::Chunk prod_alloc(tensor_prod_domain(proj, tensor), ddc::HostAllocator<double>());
+    ddc::Chunk prod_alloc(natural_tensor_prod_domain(proj, tensor), ddc::HostAllocator<double>());
     sil::tensor::Tensor<
             double,
-            sil::tensor::tensor_prod_domain_t<
+            sil::tensor::natural_tensor_prod_domain_t<
                     typename decltype(young_tableau)::projector_domain<Alpha, Beta, Gamma>,
                     ddc::DiscreteDomain<Alpha, Beta, Gamma>>,
             std::experimental::layout_right,
             Kokkos::DefaultHostExecutionSpace::memory_space>
             prod(prod_alloc);
 
-    sil::tensor::tensor_prod(prod, proj, tensor);
+    sil::tensor::natural_tensor_prod(prod, proj, tensor);
 
-    sil::tensor::tensor_accessor_for_domain_t<sil::tensor::tensor_prod_domain_t<
+    sil::tensor::tensor_accessor_for_domain_t<sil::tensor::natural_tensor_prod_domain_t<
             typename decltype(young_tableau)::projector_domain<Alpha, Beta, Gamma>,
             ddc::DiscreteDomain<Alpha, Beta, Gamma>>>
             tensor_accessor_prod;
@@ -483,19 +483,19 @@ TEST(YoungTableau, 1_2l3)
 
     auto [proj_alloc, proj] = young_tableau.projector<Alpha, Beta, Gamma>();
 
-    ddc::Chunk prod_alloc(tensor_prod_domain(proj, tensor), ddc::HostAllocator<double>());
+    ddc::Chunk prod_alloc(natural_tensor_prod_domain(proj, tensor), ddc::HostAllocator<double>());
     sil::tensor::Tensor<
             double,
-            sil::tensor::tensor_prod_domain_t<
+            sil::tensor::natural_tensor_prod_domain_t<
                     typename decltype(young_tableau)::projector_domain<Alpha, Beta, Gamma>,
                     ddc::DiscreteDomain<Alpha, Beta, Gamma>>,
             std::experimental::layout_right,
             Kokkos::DefaultHostExecutionSpace::memory_space>
             prod(prod_alloc);
 
-    sil::tensor::tensor_prod(prod, proj, tensor);
+    sil::tensor::natural_tensor_prod(prod, proj, tensor);
 
-    sil::tensor::tensor_accessor_for_domain_t<sil::tensor::tensor_prod_domain_t<
+    sil::tensor::tensor_accessor_for_domain_t<sil::tensor::natural_tensor_prod_domain_t<
             typename decltype(young_tableau)::projector_domain<Alpha, Beta, Gamma>,
             ddc::DiscreteDomain<Alpha, Beta, Gamma>>>
             tensor_accessor_prod;
@@ -555,19 +555,19 @@ TEST(YoungTableau, 1_3l2)
 
     auto [proj_alloc, proj] = young_tableau.projector<Alpha, Beta, Gamma>();
 
-    ddc::Chunk prod_alloc(tensor_prod_domain(proj, tensor), ddc::HostAllocator<double>());
+    ddc::Chunk prod_alloc(natural_tensor_prod_domain(proj, tensor), ddc::HostAllocator<double>());
     sil::tensor::Tensor<
             double,
-            sil::tensor::tensor_prod_domain_t<
+            sil::tensor::natural_tensor_prod_domain_t<
                     typename decltype(young_tableau)::projector_domain<Alpha, Beta, Gamma>,
                     ddc::DiscreteDomain<Alpha, Beta, Gamma>>,
             std::experimental::layout_right,
             Kokkos::DefaultHostExecutionSpace::memory_space>
             prod(prod_alloc);
 
-    sil::tensor::tensor_prod(prod, proj, tensor);
+    sil::tensor::natural_tensor_prod(prod, proj, tensor);
 
-    sil::tensor::tensor_accessor_for_domain_t<sil::tensor::tensor_prod_domain_t<
+    sil::tensor::tensor_accessor_for_domain_t<sil::tensor::natural_tensor_prod_domain_t<
             typename decltype(young_tableau)::projector_domain<Alpha, Beta, Gamma>,
             ddc::DiscreteDomain<Alpha, Beta, Gamma>>>
             tensor_accessor_prod;
@@ -682,19 +682,19 @@ TEST(YoungTableau, 1l3_2l4)
 
     auto [proj_alloc, proj] = young_tableau.projector<Alpha, Beta, Gamma, Delta>();
 
-    ddc::Chunk prod_alloc(tensor_prod_domain(proj, tensor), ddc::HostAllocator<double>());
+    ddc::Chunk prod_alloc(natural_tensor_prod_domain(proj, tensor), ddc::HostAllocator<double>());
     sil::tensor::Tensor<
             double,
-            sil::tensor::tensor_prod_domain_t<
+            sil::tensor::natural_tensor_prod_domain_t<
                     typename decltype(young_tableau)::projector_domain<Alpha, Beta, Gamma, Delta>,
                     ddc::DiscreteDomain<Alpha, Beta, Gamma, Delta>>,
             std::experimental::layout_right,
             Kokkos::DefaultHostExecutionSpace::memory_space>
             prod(prod_alloc);
 
-    sil::tensor::tensor_prod(prod, proj, tensor);
+    sil::tensor::natural_tensor_prod(prod, proj, tensor);
 
-    sil::tensor::tensor_accessor_for_domain_t<sil::tensor::tensor_prod_domain_t<
+    sil::tensor::tensor_accessor_for_domain_t<sil::tensor::natural_tensor_prod_domain_t<
             typename decltype(young_tableau)::projector_domain<Alpha, Beta, Gamma, Delta>,
             ddc::DiscreteDomain<Alpha, Beta, Gamma, Delta>>>
             tensor_accessor_prod;

--- a/tests/young_tableau/young_tableau.cpp
+++ b/tests/young_tableau/young_tableau.cpp
@@ -6,7 +6,7 @@
 #include <gtest/gtest.h>
 
 #include "tensor.hpp"
-// #include "young_tableau.hpp"
+#include "young_tableau.hpp"
 
 struct X
 {


### PR DESCRIPTION
- Fixes
- Subindex domain getters in TensorIndex classes
- TensorProd between naturally-indexed tensors is renamed NaturalTensorProd
- New TensorProd class implementing only tensor product between a Young tableau-indexed tensor and a dense tensor atm
- Associated test.