### PR TITLE
Tensor field

### DIFF
--- a/.devnote
+++ b/.devnote
@@ -62,3 +62,4 @@ using projector_index_t = ProjectorIndex<
 - Primary-specialization is given by not writing <>. Maybe it can simplify some implementation
 - tests for relabelize_indexes and relabelize_metric
 - Unify TensorAccessor::access_element() functions. Also get<Dims...>() in Tensor ?
+- inplace_apply_metric should not take both lower and upper indices as template arguments

--- a/.devnote
+++ b/.devnote
@@ -63,3 +63,4 @@ using projector_index_t = ProjectorIndex<
 - tests for relabelize_indexes and relabelize_metric
 - Unify TensorAccessor::access_element() functions. Also get<Dims...>() in Tensor ?
 - inplace_apply_metric should not take both lower and upper indices as template arguments and metric should rely on prime
+- rely on natural_domain_t in tensor_prod ?

--- a/.devnote
+++ b/.devnote
@@ -62,4 +62,3 @@ using projector_index_t = ProjectorIndex<
 - Primary-specialization is given by not writing <>. Maybe it can simplify some implementation
 - tests for relabelize_indexes and relabelize_metric
 - Unify TensorAccessor::access_element() functions. Also get<Dims...>() in Tensor ?
-- inplace_apply_metric should not take both lower and upper indices as template arguments

--- a/.devnote
+++ b/.devnote
@@ -62,5 +62,5 @@ using projector_index_t = ProjectorIndex<
 - Primary-specialization is given by not writing <>. Maybe it can simplify some implementation
 - tests for relabelize_indexes and relabelize_metric
 - Unify TensorAccessor::access_element() functions. Also get<Dims...>() in Tensor ?
-- inplace_apply_metric should not take both lower and upper indices as template arguments and metric should rely on prime
+- inplace_apply_metric should not take both lower and upper indices as template arguments
 - rely on natural_domain_t in tensor_prod ?

--- a/.devnote
+++ b/.devnote
@@ -63,4 +63,3 @@ using projector_index_t = ProjectorIndex<
 - tests for relabelize_indexes and relabelize_metric
 - Unify TensorAccessor::access_element() functions. Also get<Dims...>() in Tensor ?
 - inplace_apply_metric should not take both lower and upper indices as template arguments
-- rely on natural_domain_t in tensor_prod ?

--- a/.devnote
+++ b/.devnote
@@ -62,4 +62,4 @@ using projector_index_t = ProjectorIndex<
 - Primary-specialization is given by not writing <>. Maybe it can simplify some implementation
 - tests for relabelize_indexes and relabelize_metric
 - Unify TensorAccessor::access_element() functions. Also get<Dims...>() in Tensor ?
-- inplace_apply_metric should not take both lower and upper indices as template arguments
+- inplace_apply_metric should not take both lower and upper indices as template arguments and metric should rely on prime

--- a/examples/kretschmann_scalar.cpp
+++ b/examples/kretschmann_scalar.cpp
@@ -154,16 +154,14 @@ int main(int argc, char** argv)
 
     // We allocate and compute the covariant counterpart of the Riemann tensor which is needed for the computation of the Kretschmann scalar. Actually, in this particular case (Minkowski metric and even-rank tensor), contravariant and covariant Riemann tensors have the same components, but we perform the computation like if it was not the case.
     ddc::Chunk riemann_low_alloc = ddc::create_mirror_and_copy(riemann_up);
-    auto riemann_low = sil::tensor::inplace_apply_metric<
-            MetricIndex,
-            ddc::detail::TypeSeq<MuLow, NuLow, RhoLow, SigmaLow>,
-            ddc::detail::TypeSeq<MuUp, NuUp, RhoUp, SigmaUp>>(
-            sil::tensor::Tensor<
-                    double,
-                    ddc::DiscreteDomain<RiemannUpTensorIndex>,
-                    Kokkos::layout_right,
-                    Kokkos::DefaultHostExecutionSpace::memory_space>(riemann_low_alloc),
-            metric);
+    auto riemann_low
+            = sil::tensor::inplace_apply_metric<MetricIndex, MuLow, NuLow, RhoLow, SigmaLow>(
+                    sil::tensor::Tensor<
+                            double,
+                            ddc::DiscreteDomain<RiemannUpTensorIndex>,
+                            Kokkos::layout_right,
+                            Kokkos::DefaultHostExecutionSpace::memory_space>(riemann_low_alloc),
+                    metric);
 
     // We allocate the Kretschmann scalar (a single double) and perform the tensor product between covariant an contravariant Riemann tensors.
     ddc::DiscreteDomain<> dom;

--- a/examples/kretschmann_scalar.cpp
+++ b/examples/kretschmann_scalar.cpp
@@ -11,12 +11,6 @@
  * On the particular event {tau: 1/3, rho: 1, theta: math.pi/2, phi: 0}, the metric is Minkowski metric.
  */
 
-// Declare the Minkowski metric as a Lorentzian signature (-, +, +, +)
-using MetricIndex = sil::tensor::TensorLorentzianSignIndex<
-        std::integral_constant<std::size_t, 1>,
-        sil::tensor::MetricIndex1,
-        sil::tensor::MetricIndex2>;
-
 // Labelize the dimensions of space-time
 struct T
 {
@@ -33,6 +27,12 @@ struct Y
 struct Z
 {
 };
+
+// Declare the Minkowski metric as a Lorentzian signature (-, +, +, +)
+using MetricIndex = sil::tensor::TensorLorentzianSignIndex<
+        std::integral_constant<std::size_t, 1>,
+        sil::tensor::MetricIndex1<T, X, Y, Z>,
+        sil::tensor::MetricIndex2<T, X, Y, Z>>;
 
 // Declare natural indices taking values in {T, X, Y, Z}
 struct Mu : sil::tensor::TensorNaturalIndex<T, X, Y, Z>

--- a/examples/sketch.cpp
+++ b/examples/sketch.cpp
@@ -9,11 +9,6 @@
 
 static constexpr std::size_t s_degree = 3;
 
-// Declare a metric
-// using MetricIndex = sil::tensor::TensorSymmetricIndex<
-using MetricIndex
-        = sil::tensor::TensorDiagonalIndex<sil::tensor::MetricIndex1, sil::tensor::MetricIndex2>;
-
 // Labelize the dimensions of space
 struct X
 {
@@ -24,6 +19,11 @@ struct Y
 {
     static constexpr bool PERIODIC = false;
 };
+
+// Declare a metric
+// using MetricIndex = sil::tensor::TensorSymmetricIndex<
+using MetricIndex = sil::tensor::
+        TensorDiagonalIndex<sil::tensor::MetricIndex1<X, Y>, sil::tensor::MetricIndex2<X, Y>>;
 
 using MesherXY = sil::mesher::Mesher<s_degree, X, Y>;
 

--- a/examples/sketch.cpp
+++ b/examples/sketch.cpp
@@ -11,9 +11,8 @@ static constexpr std::size_t s_degree = 3;
 
 // Declare a metric
 // using MetricIndex = sil::tensor::TensorSymmetricIndex<
-using MetricIndex = sil::tensor::TensorDiagonalIndex<
-        sil::tensor::MetricIndex1,
-        sil::tensor::MetricIndex2>;
+using MetricIndex
+        = sil::tensor::TensorDiagonalIndex<sil::tensor::MetricIndex1, sil::tensor::MetricIndex2>;
 
 // Labelize the dimensions of space
 struct X
@@ -78,7 +77,8 @@ int main(int argc, char** argv)
 
     // Allocate and instantiate a metric tensor field.
     sil::tensor::TensorAccessor<MetricIndex> metric_accessor;
-    ddc::DiscreteDomain<DDimX, DDimY, MetricIndex> metric_dom(mesh_xy, metric_accessor.mem_domain());
+    ddc::DiscreteDomain<DDimX, DDimY, MetricIndex>
+            metric_dom(mesh_xy, metric_accessor.mem_domain());
     ddc::Chunk metric_alloc(metric_dom, ddc::HostAllocator<double>());
     sil::tensor::Tensor<
             double,
@@ -86,4 +86,6 @@ int main(int argc, char** argv)
             Kokkos::layout_right,
             Kokkos::DefaultHostExecutionSpace::memory_space>
             metric(metric_alloc);
+    auto gmunu = sil::tensor::relabelize_metric<MuUp, NuUp>(metric);
+    std::cout << gmunu;
 }

--- a/src/tensor/character.hpp
+++ b/src/tensor/character.hpp
@@ -21,7 +21,7 @@ struct Contravariant
 
 namespace detail {
 
-template <class NaturalIndex>
+template <class NaturalIndices>
 struct TensorNaturalIndexFromTypeSeqDim;
 
 template <class... CDim>
@@ -53,32 +53,56 @@ namespace detail {
 template <class Index>
 struct Lower;
 
-template <class NaturalIndex>
+template <TensorNatIndex NaturalIndex>
+struct Lower<TensorCovariantNaturalIndex<NaturalIndex>>
+{
+    using type = TensorCovariantNaturalIndex<NaturalIndex>;
+};
+
+template <TensorNatIndex NaturalIndex>
 struct Lower<TensorContravariantNaturalIndex<NaturalIndex>>
 {
     using type = TensorCovariantNaturalIndex<NaturalIndex>;
 };
 
+template <TensorNatIndex... NaturalIndex>
+struct Lower<ddc::detail::TypeSeq<NaturalIndex...>>
+{
+    using type = ddc::detail::TypeSeq<typename Lower<NaturalIndex>::type...>;
+};
+
 } // namespace detail
 
-template <TensorNatIndex Index>
-using lower = detail::Lower<Index>::type;
+template <class T>
+using lower = detail::Lower<T>::type;
 
 namespace detail {
 
 template <class Index>
 struct Upper;
 
-template <class NaturalIndex>
+template <TensorNatIndex NaturalIndex>
 struct Upper<TensorCovariantNaturalIndex<NaturalIndex>>
 {
     using type = TensorContravariantNaturalIndex<NaturalIndex>;
 };
 
+template <TensorNatIndex NaturalIndex>
+struct Upper<TensorContravariantNaturalIndex<NaturalIndex>>
+{
+    using type = TensorContravariantNaturalIndex<NaturalIndex>;
+};
+
+template <TensorNatIndex... NaturalIndex>
+struct Upper<ddc::detail::TypeSeq<NaturalIndex...>>
+{
+    using type = ddc::detail::TypeSeq<typename Upper<NaturalIndex>::type...>;
+};
+
 } // namespace detail
 
-template <TensorNatIndex Index>
-using upper = detail::Upper<Index>::type;
+template <class T>
+using upper = detail::Upper<T>::type;
 
 namespace detail {
 

--- a/src/tensor/metric.hpp
+++ b/src/tensor/metric.hpp
@@ -31,12 +31,26 @@ using relabelize_metric_in_domain_t = relabelize_indices_in_domain_t<
         ddc::detail::TypeSeq<MetricIndex1, MetricIndex2>,
         ddc::detail::TypeSeq<Index1, Index2>>;
 
-template <class Index1, class Index2, class Dom>
+template <TensorNatIndex Index1, TensorNatIndex Index2, class Dom>
 relabelize_metric_in_domain_t<Dom, Index1, Index2> relabelize_metric_in_domain(Dom metric_dom)
 {
     return relabelize_indices_in_domain<
             ddc::detail::TypeSeq<MetricIndex1, MetricIndex2>,
             ddc::detail::TypeSeq<Index1, Index2>>(metric_dom);
+}
+
+template <misc::Specialization<Tensor> TensorType, TensorNatIndex Index1, TensorNatIndex Index2>
+using relabelize_metric_t = relabelize_indices_of_t<
+        TensorType,
+        ddc::detail::TypeSeq<MetricIndex1, MetricIndex2>,
+        ddc::detail::TypeSeq<Index1, Index2>>;
+
+template <TensorNatIndex Index1, TensorNatIndex Index2, misc::Specialization<Tensor> TensorType>
+relabelize_metric_t<TensorType, Index1, Index2> relabelize_metric(TensorType tensor)
+{
+    return relabelize_indices_of<
+            ddc::detail::TypeSeq<MetricIndex1, MetricIndex2>,
+            ddc::detail::TypeSeq<Index1, Index2>>(tensor);
 }
 
 // Compute domain for a tensor product of metrics (ie. g_mu_muprime*g_nu_nuprime*...)

--- a/src/tensor/metric.hpp
+++ b/src/tensor/metric.hpp
@@ -215,12 +215,14 @@ struct FillMetricProd<
                 Kokkos::DefaultHostExecutionSpace::memory_space>
                 new_metric_prod_(new_metric_prod_alloc_);
 
-        ddc::for_each(new_metric_prod_.non_indices_domain(), [&](auto elem) {
-            tensor_prod(
-                    new_metric_prod_[elem],
-                    metric_prod_[elem],
-                    relabelize_metric<HeadIndex1, HeadIndex2>(metric)[elem]);
-        });
+        if (new_metric_prod_dom_.size() != 0) {
+            ddc::for_each(new_metric_prod_.non_indices_domain(), [&](auto elem) {
+                tensor_prod(
+                        new_metric_prod_[elem],
+                        metric_prod_[elem],
+                        relabelize_metric<HeadIndex1, HeadIndex2>(metric)[elem]);
+            });
+        }
 
 
         return FillMetricProd<

--- a/src/tensor/metric.hpp
+++ b/src/tensor/metric.hpp
@@ -13,13 +13,38 @@ namespace sil {
 namespace tensor {
 
 // Abstract indices used to characterize a generic metric
-struct MetricIndex1 : TensorNaturalIndex<>
+
+template <class... CDim>
+struct MetricIndex1 : TensorNaturalIndex<CDim...>
 {
 };
 
-struct MetricIndex2 : TensorNaturalIndex<>
+template <class... CDim>
+struct MetricIndex2 : TensorNaturalIndex<CDim...>
 {
 };
+
+namespace detail {
+
+template <class TypeSeqCDim>
+struct ConvertTypeSeqToMetricIndex1;
+
+template <class... CDim>
+struct ConvertTypeSeqToMetricIndex1<ddc::detail::TypeSeq<CDim...>>
+{
+    using type = MetricIndex1<CDim...>;
+};
+
+template <class TypeSeqCDim>
+struct ConvertTypeSeqToMetricIndex2;
+
+template <class... CDim>
+struct ConvertTypeSeqToMetricIndex2<ddc::detail::TypeSeq<CDim...>>
+{
+    using type = MetricIndex2<CDim...>;
+};
+
+} // namespace detail
 
 // Relabelize metric
 template <
@@ -28,28 +53,44 @@ template <
         TensorNatIndex Index2>
 using relabelize_metric_in_domain_t = relabelize_indices_in_domain_t<
         Dom,
-        ddc::detail::TypeSeq<MetricIndex1, MetricIndex2>,
+        ddc::detail::TypeSeq<
+                typename detail::ConvertTypeSeqToMetricIndex1<
+                        typename Index1::type_seq_dimensions>::type,
+                typename detail::ConvertTypeSeqToMetricIndex2<
+                        typename Index2::type_seq_dimensions>::type>,
         ddc::detail::TypeSeq<Index1, Index2>>;
 
 template <TensorNatIndex Index1, TensorNatIndex Index2, class Dom>
 relabelize_metric_in_domain_t<Dom, Index1, Index2> relabelize_metric_in_domain(Dom metric_dom)
 {
     return relabelize_indices_in_domain<
-            ddc::detail::TypeSeq<MetricIndex1, MetricIndex2>,
+            ddc::detail::TypeSeq<
+                    typename detail::ConvertTypeSeqToMetricIndex1<
+                            typename Index1::type_seq_dimensions>::type,
+                    typename detail::ConvertTypeSeqToMetricIndex2<
+                            typename Index2::type_seq_dimensions>::type>,
             ddc::detail::TypeSeq<Index1, Index2>>(metric_dom);
 }
 
 template <misc::Specialization<Tensor> TensorType, TensorNatIndex Index1, TensorNatIndex Index2>
 using relabelize_metric_t = relabelize_indices_of_t<
         TensorType,
-        ddc::detail::TypeSeq<MetricIndex1, MetricIndex2>,
+        ddc::detail::TypeSeq<
+                typename detail::ConvertTypeSeqToMetricIndex1<
+                        typename Index1::type_seq_dimensions>::type,
+                typename detail::ConvertTypeSeqToMetricIndex2<
+                        typename Index2::type_seq_dimensions>::type>,
         ddc::detail::TypeSeq<Index1, Index2>>;
 
 template <TensorNatIndex Index1, TensorNatIndex Index2, misc::Specialization<Tensor> TensorType>
 relabelize_metric_t<TensorType, Index1, Index2> relabelize_metric(TensorType tensor)
 {
     return relabelize_indices_of<
-            ddc::detail::TypeSeq<MetricIndex1, MetricIndex2>,
+            ddc::detail::TypeSeq<
+                    typename detail::ConvertTypeSeqToMetricIndex1<
+                            typename Index1::type_seq_dimensions>::type,
+                    typename detail::ConvertTypeSeqToMetricIndex2<
+                            typename Index2::type_seq_dimensions>::type>,
             ddc::detail::TypeSeq<Index1, Index2>>(tensor);
 }
 

--- a/src/tensor/metric.hpp
+++ b/src/tensor/metric.hpp
@@ -215,7 +215,6 @@ struct FillMetricProd<
                 Kokkos::DefaultHostExecutionSpace::memory_space>
                 new_metric_prod_(new_metric_prod_alloc_);
 
-        // tensor_prod(new_metric_prod_, metric_prod_, relabelize_metric<HeadIndex1, HeadIndex2>(metric));
         ddc::for_each(new_metric_prod_.non_indices_domain(), [&](auto elem) {
             tensor_prod(
                     new_metric_prod_[elem],
@@ -223,8 +222,6 @@ struct FillMetricProd<
                     relabelize_metric<HeadIndex1, HeadIndex2>(metric)[elem]);
         });
 
-
-        // TODO tensorial prod ? atm supports only Identity or Lorentzian metrics (new_metric_prod is empty)
 
         return FillMetricProd<
                 ddc::detail::TypeSeq<TailIndex1...>,
@@ -252,6 +249,7 @@ fill_metric_prod(
             Kokkos::layout_right,
             Kokkos::DefaultHostExecutionSpace::memory_space>
             metric_prod_(metric_prod_alloc_);
+    ddc::parallel_fill(metric_prod_, 1.);
 
     return detail::FillMetricProd<Indices1, Indices2>::run(metric_prod, metric, metric_prod_);
 }
@@ -287,7 +285,6 @@ relabelize_indices_of_t<TensorType, Indices2, Indices1> inplace_apply_metric(
             metric_prod(metric_prod_alloc);
 
     fill_metric_prod<MetricIndex, Indices1, primes<Indices1>>(metric_prod, metric);
-    std::cout << metric_prod;
 
     ddc::Chunk result_alloc(
             relabelize_indices_in_domain<Indices2, Indices1>(tensor.domain()),

--- a/src/tensor/metric.hpp
+++ b/src/tensor/metric.hpp
@@ -282,13 +282,10 @@ relabelize_indices_of_t<TensorType, Indices2, Indices1> inplace_apply_metric(
             ddc::HostAllocator<double>());
     relabelize_indices_of_t<TensorType, Indices2, Indices1> result(result_alloc);
     ddc::for_each(tensor.non_indices_domain(), [&](auto elem) {
-        std::cout << result[elem];
-/*
         tensor_prod(
                 result[elem],
                 relabelize_indices_of<Indices2, primes<Indices1>>(metric_prod)[elem],
                 relabelize_indices_of<Indices2, primes<Indices2>>(tensor)[elem]);
-*/
     });
     Kokkos::deep_copy(
             tensor.allocation_kokkos_view(),

--- a/src/tensor/metric.hpp
+++ b/src/tensor/metric.hpp
@@ -280,11 +280,12 @@ template <
         TensorIndex Index2,
         misc::Specialization<Tensor> MetricType,
         misc::Specialization<Tensor> TensorType>
-relabelize_indices_of_t<TensorType, Index1, Index2> inplace_apply_metric(
+relabelize_index_of_t<TensorType, Index2, Index1> inplace_apply_metric(
         TensorType tensor,
         MetricType metric)
 {
     return inplace_apply_metric<
+            MetricIndex,
             ddc::detail::TypeSeq<Index1>,
             ddc::detail::TypeSeq<Index2>>(tensor, metric);
 }

--- a/src/tensor/tensor_impl.hpp
+++ b/src/tensor/tensor_impl.hpp
@@ -589,20 +589,7 @@ public:
                 accessor_t::access_element(
                         typename accessor_t::natural_domain_t::discrete_element_type(elem...)),
                 typename non_indices_domain_t::discrete_element_type(elem...));
-    }
-
-    template <class... DElems>
-    KOKKOS_FUNCTION ElementType get(DElems const&... delems) const noexcept
-    {
-        return detail::Access<
-                Tensor<ElementType,
-                       ddc::DiscreteDomain<DDim...>,
-                       Kokkos::layout_right,
-                       MemorySpace>,
-                ddc::DiscreteElement<DDim...>,
-                ddc::detail::TypeSeq<>,
-                DDim...>::run(*this, ddc::DiscreteElement<DDim...>(delems...));
-    }
+    } 
 
     template <class... DElems>
     KOKKOS_FUNCTION constexpr reference mem(DElems const&... delems) const noexcept
@@ -643,6 +630,23 @@ public:
                              MemorySpace>::
                              operator[](ddc::DiscreteElement<ODDim...>(
                                      detail::LambdaMemElem<ODDim>::run(slice_spec)...)));
+    }
+
+    template <class... DElems>
+    KOKKOS_FUNCTION ElementType get(DElems const&... delems) const noexcept
+    {
+        if constexpr (sizeof...(DDim)==0) {
+           return operator()(delems...); 
+        } else {
+        return detail::Access<
+                Tensor<ElementType,
+                       ddc::DiscreteDomain<DDim...>,
+                       Kokkos::layout_right,
+                       MemorySpace>,
+                ddc::DiscreteElement<DDim...>,
+                ddc::detail::TypeSeq<>,
+                DDim...>::run(*this, ddc::DiscreteElement<DDim...>(delems...));
+        }
     }
 
     Tensor<ElementType, ddc::DiscreteDomain<DDim...>, LayoutStridedPolicy, MemorySpace>& operator+=(

--- a/src/tensor/tensor_impl.hpp
+++ b/src/tensor/tensor_impl.hpp
@@ -453,6 +453,8 @@ struct LambdaMemElem<InterestDim>
     {
         std::pair<std::vector<double>, std::vector<std::size_t>> mem_lin_comb
                 = InterestDim::access_id_to_mem_lin_comb(elem.template uid<InterestDim>());
+        assert(std::get<0>(mem_lin_comb).size() > 0
+               && "mem_elem is not defined because mem_lin_comb contains no id");
         assert(std::get<0>(mem_lin_comb).size() == 1
                && "mem_elem is not defined because mem_lin_comb contains several ids");
         return ddc::DiscreteElement<InterestDim>(std::get<1>(mem_lin_comb)[0]);

--- a/src/tensor/tensor_impl.hpp
+++ b/src/tensor/tensor_impl.hpp
@@ -96,6 +96,30 @@ concept TensorNatIndex = requires {
     { DDim::is_tensor_natural_index } -> std::convertible_to<bool>;
 } && DDim::is_tensor_natural_index;
 
+// natural_domain_t is obtained using concept and specialization
+namespace detail {
+
+template <class Index>
+struct NaturalDomainType;
+
+template <class Index>
+    requires(TensorIndex<Index> && !TensorNatIndex<Index>)
+struct NaturalDomainType<Index>
+{
+    using type = typename Index::subindices_domain_t;
+};
+
+template <TensorNatIndex Index>
+struct NaturalDomainType<Index>
+{
+    using type = ddc::DiscreteDomain<Index>;
+};
+
+} // namespace detail
+
+template <TensorIndex Index>
+using natural_domain_t = typename detail::NaturalDomainType<Index>::type;
+
 // Helpers to build the access_id() function which computes the ids of subindices of an index. This cumbersome logic is necessary because subindices do not necessarily have the same rank.
 namespace detail {
 // For Tmunu and index=nu, returns 1

--- a/src/tensor/tensor_impl.hpp
+++ b/src/tensor/tensor_impl.hpp
@@ -411,23 +411,24 @@ struct Access<TensorField, Element, ddc::detail::TypeSeq<IndexHead...>, IndexInt
 };
 
 // Functor for memory element access (if defined)
-template <typename InterestDim>
+template <class InterestDim>
 struct LambdaMemElem
 {
-    static ddc::DiscreteElement<InterestDim> run(ddc::DiscreteElement<InterestDim> elem)
+    template <class Elem>
+    static ddc::DiscreteElement<InterestDim> run(Elem elem)
     {
-        return elem;
+        return ddc::DiscreteElement<InterestDim>(elem);
     }
 };
 
 template <TensorIndex InterestDim>
 struct LambdaMemElem<InterestDim>
 {
-    static ddc::DiscreteElement<InterestDim> run(ddc::DiscreteElement<InterestDim> elem)
+    template <class Elem>
+    static ddc::DiscreteElement<InterestDim> run(Elem elem)
     {
         std::pair<std::vector<double>, std::vector<std::size_t>> mem_lin_comb
-                = InterestDim::access_id_to_mem_lin_comb(
-                        ddc::DiscreteElement<InterestDim>(elem).uid());
+                = InterestDim::access_id_to_mem_lin_comb(elem.template uid<InterestDim>());
         assert(std::get<0>(mem_lin_comb).size() == 1
                && "mem_elem is not defined because mem_lin_comb contains several ids");
         return ddc::DiscreteElement<InterestDim>(std::get<1>(mem_lin_comb)[0]);

--- a/src/tensor/tensor_impl.hpp
+++ b/src/tensor/tensor_impl.hpp
@@ -576,7 +576,7 @@ public:
                        MemorySpace>,
                 ddc::DiscreteElement<DDim...>,
                 ddc::detail::TypeSeq<>,
-                DDim...>::run(*this, ddc::DiscreteElement(delems...));
+                DDim...>::run(*this, ddc::DiscreteElement<DDim...>(delems...));
     }
 
     template <class... DElems>

--- a/src/tensor/tensor_impl.hpp
+++ b/src/tensor/tensor_impl.hpp
@@ -589,7 +589,7 @@ public:
                 accessor_t::access_element(
                         typename accessor_t::natural_domain_t::discrete_element_type(elem...)),
                 typename non_indices_domain_t::discrete_element_type(elem...));
-    } 
+    }
 
     template <class... DElems>
     KOKKOS_FUNCTION constexpr reference mem(DElems const&... delems) const noexcept
@@ -635,17 +635,17 @@ public:
     template <class... DElems>
     KOKKOS_FUNCTION ElementType get(DElems const&... delems) const noexcept
     {
-        if constexpr (sizeof...(DDim)==0) {
-           return operator()(delems...); 
+        if constexpr (sizeof...(DDim) == 0) {
+            return operator()(delems...);
         } else {
-        return detail::Access<
-                Tensor<ElementType,
-                       ddc::DiscreteDomain<DDim...>,
-                       Kokkos::layout_right,
-                       MemorySpace>,
-                ddc::DiscreteElement<DDim...>,
-                ddc::detail::TypeSeq<>,
-                DDim...>::run(*this, ddc::DiscreteElement<DDim...>(delems...));
+            return detail::Access<
+                    Tensor<ElementType,
+                           ddc::DiscreteDomain<DDim...>,
+                           Kokkos::layout_right,
+                           MemorySpace>,
+                    ddc::DiscreteElement<DDim...>,
+                    ddc::detail::TypeSeq<>,
+                    DDim...>::run(*this, ddc::DiscreteElement<DDim...>(delems...));
         }
     }
 

--- a/src/tensor/tensor_prod.hpp
+++ b/src/tensor/tensor_prod.hpp
@@ -131,19 +131,17 @@ tensor_prod(
         Tensor<ElementType, ddc::DiscreteDomain<Index2...>, LayoutStridedPolicy, MemorySpace>
                 tensor2)
 {
-    /* TODO restore
     static_assert(std::is_same_v<
                   ddc::type_seq_remove_t<
                           uncharacterize<ddc::to_type_seq_t<
-                                  ddc::cartesian_prod_t<typename Index1::subindices_domain_t...>>>,
-                          uncharacterize<ddc::to_type_seq_t<ddc::cartesian_prod_t<
-                                  typename ProdDDim::subindices_domain_t...>>>>,
+                                  ddc::cartesian_prod_t<natural_domain_t<Index1>...>>>,
+                          uncharacterize<ddc::to_type_seq_t<
+                                  ddc::cartesian_prod_t<natural_domain_t<ProdDDim>...>>>>,
                   ddc::type_seq_remove_t<
                           uncharacterize<ddc::to_type_seq_t<
-                                  ddc::cartesian_prod_t<typename Index2::subindices_domain_t...>>>,
-                          uncharacterize<ddc::to_type_seq_t<ddc::cartesian_prod_t<
-                                  typename ProdDDim::subindices_domain_t...>>>>>);
-    */
+                                  ddc::cartesian_prod_t<natural_domain_t<Index2>...>>>,
+                          uncharacterize<ddc::to_type_seq_t<
+                                  ddc::cartesian_prod_t<natural_domain_t<ProdDDim>...>>>>>);
     static_assert(
             std::is_same_v<
                     ddc::type_seq_remove_t<
@@ -169,19 +167,19 @@ tensor_prod(
             uncharacterize<ddc::detail::TypeSeq<Index2...>>,
             ddc::type_seq_remove_t<
                     uncharacterize<ddc::to_type_seq_t<
-                            ddc::cartesian_prod_t<typename ProdDDim::subindices_domain_t...>>>,
+                            ddc::cartesian_prod_t<natural_domain_t<ProdDDim>...>>>,
                     uncharacterize<ddc::to_type_seq_t<
-                            ddc::cartesian_prod_t<typename Index2::subindices_domain_t...>>>>,
+                            ddc::cartesian_prod_t<natural_domain_t<Index2>...>>>>,
+            ddc::type_seq_remove_t<
+                    uncharacterize<
+                            ddc::to_type_seq_t<ddc::cartesian_prod_t<natural_domain_t<Index1>...>>>,
+                    uncharacterize<ddc::to_type_seq_t<
+                            ddc::cartesian_prod_t<natural_domain_t<ProdDDim>...>>>>,
             ddc::type_seq_remove_t<
                     uncharacterize<ddc::to_type_seq_t<
-                            ddc::cartesian_prod_t<typename Index1::subindices_domain_t...>>>,
+                            ddc::cartesian_prod_t<natural_domain_t<ProdDDim>...>>>,
                     uncharacterize<ddc::to_type_seq_t<
-                            ddc::cartesian_prod_t<typename ProdDDim::subindices_domain_t...>>>>,
-            ddc::type_seq_remove_t<
-                    uncharacterize<ddc::to_type_seq_t<
-                            ddc::cartesian_prod_t<typename ProdDDim::subindices_domain_t...>>>,
-                    uncharacterize<ddc::to_type_seq_t<
-                            ddc::cartesian_prod_t<typename Index1::subindices_domain_t...>>>>>::
+                            ddc::cartesian_prod_t<natural_domain_t<Index1>...>>>>>::
             run(uncharacterize_tensor(prod_tensor),
                 uncharacterize_tensor(tensor1),
                 uncharacterize_tensor(tensor2));

--- a/src/tensor/tensor_prod.hpp
+++ b/src/tensor/tensor_prod.hpp
@@ -85,10 +85,10 @@ struct TensorProdAnyAnyAny<
         ddc::DiscreteDomain<ContractDDim...> contract_dom = contract_accessor.natural_domain();
 
         ddc::for_each(
-                prod_tensor.domain(),
-                [&](ddc::cartesian_prod_t<
-                        typename ProdDDim::subindices_domain_t...>::discrete_element_type elem) {
-                    prod_tensor(elem) = ddc::transform_reduce(
+                prod_tensor.natural_domain(), // TODO iterate on access_domain, not natural_domain
+                [&](ddc::cartesian_prod_t<natural_domain_t<ProdDDim>...>::discrete_element_type
+                            elem) {
+                    prod_tensor(prod_tensor.access_element(elem)) = ddc::transform_reduce(
                             contract_dom,
                             0.,
                             ddc::reducer::sum<ElementType>(),

--- a/src/tensor/tensor_prod.hpp
+++ b/src/tensor/tensor_prod.hpp
@@ -43,6 +43,151 @@ static constexpr subindices_domain_t<T> subindices_domain()
     return detail::SubindicesDomain<T>::run();
 };
 
+// Any-any product into Any (general case not optimized)
+namespace detail {
+
+template <
+        class ProdIndices,
+        class Indices1,
+        class Indices2,
+        class HeadDDim1TypeSeq,
+        class ContractDDimTypeSeq,
+        class TailDDim2TypeSeq>
+struct TensorProdAnyAnyAny;
+
+template <
+        class... ProdDDim,
+        class... Index1,
+        class... Index2,
+        class... HeadDDim1,
+        class... ContractDDim,
+        class... TailDDim2>
+struct TensorProdAnyAnyAny<
+        ddc::detail::TypeSeq<ProdDDim...>,
+        ddc::detail::TypeSeq<Index1...>,
+        ddc::detail::TypeSeq<Index2...>,
+        ddc::detail::TypeSeq<HeadDDim1...>,
+        ddc::detail::TypeSeq<ContractDDim...>,
+        ddc::detail::TypeSeq<TailDDim2...>>
+{
+    template <class ElementType, class LayoutStridedPolicy, class MemorySpace>
+    static Tensor<ElementType, ddc::DiscreteDomain<ProdDDim...>, LayoutStridedPolicy, MemorySpace>
+    run(Tensor<ElementType,
+               ddc::DiscreteDomain<ProdDDim...>,
+               Kokkos::layout_right,
+               Kokkos::DefaultHostExecutionSpace::memory_space> prod_tensor,
+        Tensor<ElementType, ddc::DiscreteDomain<Index1...>, LayoutStridedPolicy, MemorySpace>
+                tensor1,
+        Tensor<ElementType, ddc::DiscreteDomain<Index2...>, LayoutStridedPolicy, MemorySpace>
+                tensor2)
+    {
+        tensor::TensorAccessor<ContractDDim...> contract_accessor;
+        ddc::DiscreteDomain<ContractDDim...> contract_dom = contract_accessor.natural_domain();
+
+        ddc::for_each(
+                prod_tensor.domain(),
+                [&](ddc::cartesian_prod_t<
+                        typename ProdDDim::subindices_domain_t...>::discrete_element_type elem) {
+                    prod_tensor(elem) = ddc::transform_reduce(
+                            contract_dom,
+                            0.,
+                            ddc::reducer::sum<ElementType>(),
+                            [&](ddc::DiscreteElement<ContractDDim...> contract_elem) {
+                                return tensor1.get(tensor1.access_element(
+                                               ddc::DiscreteElement<HeadDDim1..., ContractDDim...>(
+                                                       ddc::select<HeadDDim1...>(elem),
+                                                       contract_accessor.access_element(
+                                                               contract_elem))))
+                                       * tensor2.get(tensor2.access_element(
+                                               ddc::DiscreteElement<ContractDDim..., TailDDim2...>(
+                                                       contract_elem,
+                                                       ddc::select<TailDDim2...>(elem))));
+                            });
+                });
+        return prod_tensor;
+    }
+};
+
+} // namespace detail
+
+template <
+        class... ProdDDim,
+        class... Index1,
+        class... Index2,
+        class ElementType,
+        class LayoutStridedPolicy,
+        class MemorySpace>
+Tensor<ElementType,
+       ddc::DiscreteDomain<ProdDDim...>,
+       Kokkos::layout_right,
+       Kokkos::DefaultHostExecutionSpace::memory_space>
+tensor_prod(
+        Tensor<ElementType,
+               ddc::DiscreteDomain<ProdDDim...>,
+               Kokkos::layout_right,
+               Kokkos::DefaultHostExecutionSpace::memory_space> prod_tensor,
+        Tensor<ElementType, ddc::DiscreteDomain<Index1...>, LayoutStridedPolicy, MemorySpace>
+                tensor1,
+        Tensor<ElementType, ddc::DiscreteDomain<Index2...>, LayoutStridedPolicy, MemorySpace>
+                tensor2)
+{
+    /* TODO restore
+    static_assert(std::is_same_v<
+                  ddc::type_seq_remove_t<
+                          uncharacterize<ddc::to_type_seq_t<
+                                  ddc::cartesian_prod_t<typename Index1::subindices_domain_t...>>>,
+                          uncharacterize<ddc::to_type_seq_t<ddc::cartesian_prod_t<
+                                  typename ProdDDim::subindices_domain_t...>>>>,
+                  ddc::type_seq_remove_t<
+                          uncharacterize<ddc::to_type_seq_t<
+                                  ddc::cartesian_prod_t<typename Index2::subindices_domain_t...>>>,
+                          uncharacterize<ddc::to_type_seq_t<ddc::cartesian_prod_t<
+                                  typename ProdDDim::subindices_domain_t...>>>>>);
+    */
+    static_assert(
+            std::is_same_v<
+                    ddc::type_seq_remove_t<
+                            ddc::to_type_seq_t<
+                                    ddc::cartesian_prod_t<typename Index1::subindices_domain_t...>>,
+                            ddc::to_type_seq_t<ddc::cartesian_prod_t<
+                                    typename Index2::subindices_domain_t...>>>,
+                    ddc::to_type_seq_t<
+                            ddc::cartesian_prod_t<typename Index1::subindices_domain_t...>>>
+            && std::is_same_v<
+                    ddc::type_seq_remove_t<
+                            ddc::to_type_seq_t<
+                                    ddc::cartesian_prod_t<typename Index2::subindices_domain_t...>>,
+                            ddc::to_type_seq_t<ddc::cartesian_prod_t<
+                                    typename Index1::subindices_domain_t...>>>,
+                    ddc::to_type_seq_t<ddc::cartesian_prod_t<
+                            typename Index2::
+                                    subindices_domain_t...>>>); // tensor1 and tensor2 should not have any subindex in common because their characters are different
+
+    detail::TensorProdAnyAnyAny<
+            uncharacterize<ddc::detail::TypeSeq<ProdDDim...>>,
+            uncharacterize<ddc::detail::TypeSeq<Index1...>>,
+            uncharacterize<ddc::detail::TypeSeq<Index2...>>,
+            ddc::type_seq_remove_t<
+                    uncharacterize<ddc::to_type_seq_t<
+                            ddc::cartesian_prod_t<typename ProdDDim::subindices_domain_t...>>>,
+                    uncharacterize<ddc::to_type_seq_t<
+                            ddc::cartesian_prod_t<typename Index2::subindices_domain_t...>>>>,
+            ddc::type_seq_remove_t<
+                    uncharacterize<ddc::to_type_seq_t<
+                            ddc::cartesian_prod_t<typename Index1::subindices_domain_t...>>>,
+                    uncharacterize<ddc::to_type_seq_t<
+                            ddc::cartesian_prod_t<typename ProdDDim::subindices_domain_t...>>>>,
+            ddc::type_seq_remove_t<
+                    uncharacterize<ddc::to_type_seq_t<
+                            ddc::cartesian_prod_t<typename ProdDDim::subindices_domain_t...>>>,
+                    uncharacterize<ddc::to_type_seq_t<
+                            ddc::cartesian_prod_t<typename Index1::subindices_domain_t...>>>>>::
+            run(uncharacterize_tensor(prod_tensor),
+                uncharacterize_tensor(tensor1),
+                uncharacterize_tensor(tensor2));
+    return prod_tensor;
+}
+
 // Young-dense product
 namespace detail {
 

--- a/src/tensor/tensor_prod.hpp
+++ b/src/tensor/tensor_prod.hpp
@@ -121,7 +121,6 @@ tensor_prod(
                   ddc::type_seq_remove_t<
                           ddc::detail::TypeSeq<DDim2...>,
                           ddc::detail::TypeSeq<ProdDDim...>>>);
-    std::cout << "test";
     return detail::TensorProd<
             Index1,
             ddc::type_seq_remove_t<

--- a/tests/tensor/CMakeLists.txt
+++ b/tests/tensor/CMakeLists.txt
@@ -24,3 +24,14 @@ target_link_libraries(unit_tests_tensor_prod
 )
 
 gtest_discover_tests(unit_tests_tensor_prod DISCOVERY_MODE PRE_TEST)
+
+add_executable(unit_tests_tensor_field tensor_field.cpp ../main.cpp)
+
+target_link_libraries(unit_tests_tensor_field
+    PUBLIC
+        GTest::gtest
+        DDC::DDC
+        sil::tensor
+)
+
+gtest_discover_tests(unit_tests_tensor_field DISCOVERY_MODE PRE_TEST)

--- a/tests/tensor/tensor_field.cpp
+++ b/tests/tensor/tensor_field.cpp
@@ -23,15 +23,15 @@ struct DDimY : ddc::UniformPointSampling<Y>
 {
 };
 
-struct Mu : sil::tensor::TensorNaturalIndex<X, Y>
+struct I : sil::tensor::TensorNaturalIndex<X, Y>
 {
 };
 
-struct Nu : sil::tensor::TensorNaturalIndex<X, Y>
+struct J : sil::tensor::TensorNaturalIndex<X, Y>
 {
 };
 
-using MetricLikeIndex = sil::tensor::TensorSymmetricIndex<Mu, Nu>;
+using MetricLikeIndex = sil::tensor::TensorSymmetricIndex<I, J>;
 
 TEST(TensorField, MetricLike)
 {
@@ -55,12 +55,122 @@ TEST(TensorField, MetricLike)
         metric(elem, metric.accessor().access_element<X, Y>()) = 2.;
         metric(elem, metric.accessor().access_element<Y, Y>()) = 3.;
     });
-    std::cout << metric;
     ddc::for_each(mesh_xy, [&](ddc::DiscreteElement<DDimX, DDimY> elem) {
-        EXPECT_EQ(metric.get(elem, metric.accessor().access_element<X, X>()), 0.);
-        /*
+        EXPECT_EQ(metric.get(elem, metric.accessor().access_element<X, X>()), 1.);
         EXPECT_EQ(metric.get(elem, metric.accessor().access_element<X, Y>()), 2.);
         EXPECT_EQ(metric.get(elem, metric.accessor().access_element<Y, Y>()), 3.);
-        */
+    });
+}
+
+using ILow = sil::tensor::TensorCovariantNaturalIndex<I>;
+using JLow = sil::tensor::TensorCovariantNaturalIndex<J>;
+
+using MetricIndex = sil::tensor::
+        TensorSymmetricIndex<sil::tensor::MetricIndex1<X, Y>, sil::tensor::MetricIndex2<X, Y>>;
+
+TEST(TensorField, Metric)
+{
+    ddc::DiscreteDomain<DDimX, DDimY>
+            mesh_xy(ddc::DiscreteElement<DDimX, DDimY>(0, 0),
+                    ddc::DiscreteVector<DDimX, DDimY>(10, 10));
+
+    sil::tensor::TensorAccessor<MetricIndex> metric_accessor;
+    ddc::DiscreteDomain<DDimX, DDimY, MetricIndex>
+            metric_dom(mesh_xy, metric_accessor.mem_domain());
+    ddc::Chunk metric_alloc(metric_dom, ddc::HostAllocator<double>());
+    sil::tensor::Tensor<
+            double,
+            ddc::DiscreteDomain<DDimX, DDimY, MetricIndex>,
+            Kokkos::layout_right,
+            Kokkos::DefaultHostExecutionSpace::memory_space>
+            metric(metric_alloc);
+    auto g_i_j = sil::tensor::relabelize_metric<ILow, JLow>(metric);
+    ddc::for_each(mesh_xy, [&](ddc::DiscreteElement<DDimX, DDimY> elem) {
+        g_i_j(elem, g_i_j.accessor().access_element<X, X>()) = 1.;
+        g_i_j(elem, g_i_j.accessor().access_element<X, Y>()) = 2.;
+        g_i_j(elem, g_i_j.accessor().access_element<Y, Y>()) = 3.;
+    });
+    ddc::for_each(mesh_xy, [&](ddc::DiscreteElement<DDimX, DDimY> elem) {
+        EXPECT_EQ(g_i_j.get(elem, g_i_j.accessor().access_element<X, X>()), 1.);
+        EXPECT_EQ(g_i_j.get(elem, g_i_j.accessor().access_element<X, Y>()), 2.);
+        EXPECT_EQ(g_i_j.get(elem, g_i_j.accessor().access_element<Y, X>()), 2.);
+        EXPECT_EQ(g_i_j.get(elem, g_i_j.accessor().access_element<Y, Y>()), 3.);
+    });
+}
+
+struct K : sil::tensor::TensorNaturalIndex<X, Y>
+{
+};
+
+using KLow = sil::tensor::TensorCovariantNaturalIndex<K>;
+using KUp = sil::tensor::upper<KLow>;
+
+TEST(TensorField, ChristoffelLike)
+{
+    ddc::DiscreteDomain<DDimX, DDimY>
+            mesh_xy(ddc::DiscreteElement<DDimX, DDimY>(0, 0),
+                    ddc::DiscreteVector<DDimX, DDimY>(10, 10));
+
+    sil::tensor::TensorAccessor<MetricIndex> metric_accessor;
+    ddc::DiscreteDomain<DDimX, DDimY, MetricIndex>
+            metric_dom(mesh_xy, metric_accessor.mem_domain());
+    ddc::Chunk metric_alloc(metric_dom, ddc::HostAllocator<double>());
+    sil::tensor::Tensor<
+            double,
+            ddc::DiscreteDomain<DDimX, DDimY, MetricIndex>,
+            Kokkos::layout_right,
+            Kokkos::DefaultHostExecutionSpace::memory_space>
+            metric(metric_alloc);
+    auto g_i_j = sil::tensor::relabelize_metric<ILow, JLow>(metric);
+    ddc::for_each(mesh_xy, [&](ddc::DiscreteElement<DDimX, DDimY> elem) {
+        g_i_j(elem, g_i_j.accessor().access_element<X, X>()) = 1.;
+        g_i_j(elem, g_i_j.accessor().access_element<X, Y>()) = 0.;
+        g_i_j(elem, g_i_j.accessor().access_element<Y, Y>()) = 2.;
+    });
+
+    sil::tensor::TensorAccessor<KUp, sil::tensor::TensorSymmetricIndex<ILow, JLow>>
+            christoffel_1st_accessor;
+    ddc::DiscreteDomain<DDimX, DDimY, KUp, sil::tensor::TensorSymmetricIndex<ILow, JLow>>
+            christoffel_1st_dom(mesh_xy, christoffel_1st_accessor.mem_domain());
+    ddc::Chunk christoffel_1st_alloc(christoffel_1st_dom, ddc::HostAllocator<double>());
+    sil::tensor::Tensor<
+            double,
+            ddc::DiscreteDomain<DDimX, DDimY, KUp, sil::tensor::TensorSymmetricIndex<ILow, JLow>>,
+            Kokkos::layout_right,
+            Kokkos::DefaultHostExecutionSpace::memory_space>
+            christoffel_1st(christoffel_1st_alloc);
+    ddc::for_each(mesh_xy, [&](ddc::DiscreteElement<DDimX, DDimY> elem) {
+        christoffel_1st(elem, christoffel_1st.accessor().access_element<X, X, X>()) = 1.;
+        christoffel_1st(elem, christoffel_1st.accessor().access_element<X, X, Y>()) = 2.;
+        christoffel_1st(elem, christoffel_1st.accessor().access_element<X, Y, Y>()) = 3.;
+        christoffel_1st(elem, christoffel_1st.accessor().access_element<Y, X, X>()) = 4.;
+        christoffel_1st(elem, christoffel_1st.accessor().access_element<Y, X, Y>()) = 5.;
+        christoffel_1st(elem, christoffel_1st.accessor().access_element<Y, Y, Y>()) = 6.;
+    });
+    ddc::for_each(mesh_xy, [&](ddc::DiscreteElement<DDimX, DDimY> elem) {
+        EXPECT_EQ(
+                christoffel_1st.get(elem, christoffel_1st.accessor().access_element<X, X, X>()),
+                1.);
+        EXPECT_EQ(
+                christoffel_1st.get(elem, christoffel_1st.accessor().access_element<X, X, Y>()),
+                2.);
+        EXPECT_EQ(
+                christoffel_1st.get(elem, christoffel_1st.accessor().access_element<X, Y, X>()),
+                2.);
+        EXPECT_EQ(
+                christoffel_1st.get(elem, christoffel_1st.accessor().access_element<X, Y, Y>()),
+                3.);
+        EXPECT_EQ(
+                christoffel_1st.get(elem, christoffel_1st.accessor().access_element<Y, X, X>()),
+                4.);
+        EXPECT_EQ(
+                christoffel_1st.get(elem, christoffel_1st.accessor().access_element<Y, X, Y>()),
+                5.);
+        EXPECT_EQ(
+                christoffel_1st.get(elem, christoffel_1st.accessor().access_element<Y, Y, X>()),
+                5.);
+        EXPECT_EQ(
+                christoffel_1st.get(elem, christoffel_1st.accessor().access_element<Y, Y, Y>()),
+                6.);
     });
 }

--- a/tests/tensor/tensor_field.cpp
+++ b/tests/tensor/tensor_field.cpp
@@ -174,5 +174,5 @@ TEST(TensorField, ChristoffelLike)
     });
     auto christoffel_2nd
             = sil::tensor::inplace_apply_metric<MetricIndex, KLow, KUp>(christoffel_1st, metric);
-    std::cout << christoffel_2nd;
+    // std::cout << christoffel_2nd;
 }

--- a/tests/tensor/tensor_field.cpp
+++ b/tests/tensor/tensor_field.cpp
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: 2024 Baptiste Legouix
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <ddc/ddc.hpp>
+
+#include <gtest/gtest.h>
+
+#include "tensor.hpp"
+
+struct X
+{
+};
+
+struct Y
+{
+};
+
+struct DDimX : ddc::UniformPointSampling<X>
+{
+};
+
+struct DDimY : ddc::UniformPointSampling<Y>
+{
+};
+
+struct Mu : sil::tensor::TensorNaturalIndex<X, Y>
+{
+};
+
+struct Nu : sil::tensor::TensorNaturalIndex<X, Y>
+{
+};
+
+using MetricLikeIndex = sil::tensor::TensorSymmetricIndex<Mu, Nu>;
+
+TEST(TensorField, MetricLike)
+{
+    ddc::DiscreteDomain<DDimX, DDimY>
+            mesh_xy(ddc::DiscreteElement<DDimX, DDimY>(0, 0),
+                    ddc::DiscreteVector<DDimX, DDimY>(10, 10));
+
+    sil::tensor::TensorAccessor<MetricLikeIndex> metric_accessor;
+    ddc::DiscreteDomain<DDimX, DDimY, MetricLikeIndex>
+            metric_dom(mesh_xy, metric_accessor.mem_domain());
+
+    ddc::Chunk metric_alloc(metric_dom, ddc::HostAllocator<double>());
+    sil::tensor::Tensor<
+            double,
+            ddc::DiscreteDomain<DDimX, DDimY, MetricLikeIndex>,
+            Kokkos::layout_right,
+            Kokkos::DefaultHostExecutionSpace::memory_space>
+            metric(metric_alloc);
+    ddc::for_each(mesh_xy, [&](ddc::DiscreteElement<DDimX, DDimY> elem) {
+        metric(elem, metric.accessor().access_element<X, X>()) = 1.;
+        metric(elem, metric.accessor().access_element<X, Y>()) = 2.;
+        metric(elem, metric.accessor().access_element<Y, Y>()) = 3.;
+    });
+    std::cout << metric;
+    ddc::for_each(mesh_xy, [&](ddc::DiscreteElement<DDimX, DDimY> elem) {
+        EXPECT_EQ(metric.get(elem, metric.accessor().access_element<X, X>()), 0.);
+        /*
+        EXPECT_EQ(metric.get(elem, metric.accessor().access_element<X, Y>()), 2.);
+        EXPECT_EQ(metric.get(elem, metric.accessor().access_element<Y, Y>()), 3.);
+        */
+    });
+}

--- a/tests/tensor/tensor_field.cpp
+++ b/tests/tensor/tensor_field.cpp
@@ -174,5 +174,30 @@ TEST(TensorField, ChristoffelLike)
     });
     auto christoffel_2nd
             = sil::tensor::inplace_apply_metric<MetricIndex, KLow, KUp>(christoffel_1st, metric);
-    // std::cout << christoffel_2nd;
+    ddc::for_each(mesh_xy, [&](ddc::DiscreteElement<DDimX, DDimY> elem) {
+        EXPECT_EQ(
+                christoffel_2nd.get(elem, christoffel_2nd.accessor().access_element<X, X, X>()),
+                1.);
+        EXPECT_EQ(
+                christoffel_2nd.get(elem, christoffel_2nd.accessor().access_element<X, X, Y>()),
+                2.);
+        EXPECT_EQ(
+                christoffel_2nd.get(elem, christoffel_2nd.accessor().access_element<X, Y, X>()),
+                2.);
+        EXPECT_EQ(
+                christoffel_2nd.get(elem, christoffel_2nd.accessor().access_element<X, Y, Y>()),
+                3.);
+        EXPECT_EQ(
+                christoffel_2nd.get(elem, christoffel_2nd.accessor().access_element<Y, X, X>()),
+                8.);
+        EXPECT_EQ(
+                christoffel_2nd.get(elem, christoffel_2nd.accessor().access_element<Y, X, Y>()),
+                10.);
+        EXPECT_EQ(
+                christoffel_2nd.get(elem, christoffel_2nd.accessor().access_element<Y, Y, X>()),
+                10.);
+        EXPECT_EQ(
+                christoffel_2nd.get(elem, christoffel_2nd.accessor().access_element<Y, Y, Y>()),
+                12.);
+    });
 }

--- a/tests/tensor/tensor_field.cpp
+++ b/tests/tensor/tensor_field.cpp
@@ -172,6 +172,7 @@ TEST(TensorField, ChristoffelLike)
                 christoffel_1st.get(elem, christoffel_1st.accessor().access_element<Y, Y, Y>()),
                 6.);
     });
-    auto christoffel_2nd = sil::tensor::inplace_apply_metric<MetricIndex, KLow, KUp>(christoffel_1st, metric);
+    auto christoffel_2nd
+            = sil::tensor::inplace_apply_metric<MetricIndex, KLow, KUp>(christoffel_1st, metric);
     std::cout << christoffel_2nd;
 }

--- a/tests/tensor/tensor_field.cpp
+++ b/tests/tensor/tensor_field.cpp
@@ -173,7 +173,7 @@ TEST(TensorField, ChristoffelLike)
                 6.);
     });
     auto christoffel_2nd
-            = sil::tensor::inplace_apply_metric<MetricIndex, KLow, KUp>(christoffel_1st, metric);
+            = sil::tensor::inplace_apply_metric<MetricIndex, KLow>(christoffel_1st, metric);
     ddc::for_each(mesh_xy, [&](ddc::DiscreteElement<DDimX, DDimY> elem) {
         EXPECT_EQ(
                 christoffel_2nd.get(elem, christoffel_2nd.accessor().access_element<X, X, X>()),

--- a/tests/tensor/tensor_field.cpp
+++ b/tests/tensor/tensor_field.cpp
@@ -121,11 +121,10 @@ TEST(TensorField, ChristoffelLike)
             Kokkos::layout_right,
             Kokkos::DefaultHostExecutionSpace::memory_space>
             metric(metric_alloc);
-    auto g_i_j = sil::tensor::relabelize_metric<ILow, JLow>(metric);
     ddc::for_each(mesh_xy, [&](ddc::DiscreteElement<DDimX, DDimY> elem) {
-        g_i_j(elem, g_i_j.accessor().access_element<X, X>()) = 1.;
-        g_i_j(elem, g_i_j.accessor().access_element<X, Y>()) = 0.;
-        g_i_j(elem, g_i_j.accessor().access_element<Y, Y>()) = 2.;
+        metric(elem, metric.accessor().access_element<X, X>()) = 1.;
+        metric(elem, metric.accessor().access_element<X, Y>()) = 0.;
+        metric(elem, metric.accessor().access_element<Y, Y>()) = 2.;
     });
 
     sil::tensor::TensorAccessor<KUp, sil::tensor::TensorSymmetricIndex<ILow, JLow>>
@@ -173,4 +172,6 @@ TEST(TensorField, ChristoffelLike)
                 christoffel_1st.get(elem, christoffel_1st.accessor().access_element<Y, Y, Y>()),
                 6.);
     });
+    auto christoffel_2nd = sil::tensor::inplace_apply_metric<MetricIndex, KLow, KUp>(christoffel_1st, metric);
+    std::cout << christoffel_2nd;
 }


### PR DESCRIPTION
- Greatly improve `metric` API and support general metric tensors (ie. symmetric)
- `natural_domain_t<>` gives natural domain from non-necessarily natural indices
- Greatly improve `Tensor` class with new methods and type traits to support tensor fields.
- Use concepts in `tensor_prod` to determine which specialization is chosen. Use `tensor_prod` on tensor fields.
- Build metric tensor field in `sketch`.
- Test tensor fields and (indirectly metric and product).