### PR TITLE
Consteval Tensor::access_element

### DIFF
--- a/src/misc/binomial_coefficient.hpp
+++ b/src/misc/binomial_coefficient.hpp
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2024 Baptiste Legouix
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <ddc/ddc.hpp>
+
+namespace sil {
+
+namespace misc {
+
+// From https://stackoverflow.com/a/44719219
+constexpr inline std::size_t binomial_coefficient(std::size_t n, std::size_t k) noexcept
+{
+    return (k > n) ? 0 : // out of range
+                   (k == 0 || k == n) ? 1
+                                      : // edge
+                   (k == 1 || k == n - 1) ? n
+                                          : // first
+                   binomial_coefficient(n - 1, k - 1) * n / k; // recursive
+}
+
+} // namespace misc
+
+} // namespace sil

--- a/src/tensor/antisymmetric_tensor.hpp
+++ b/src/tensor/antisymmetric_tensor.hpp
@@ -5,8 +5,7 @@
 
 #include <ddc/ddc.hpp>
 
-#include <boost/math/special_functions/binomial.hpp>
-
+#include "binomial_coefficient.hpp"
 #include "tensor_impl.hpp"
 
 namespace sil {
@@ -41,8 +40,9 @@ struct TensorAntisymmetricIndex
 
     static constexpr std::size_t mem_size()
     {
-        return boost::math::binomial_coefficient<
-                double>(std::min({TensorIndex::mem_size()...}), sizeof...(TensorIndex));
+        return misc::binomial_coefficient(
+                std::min({TensorIndex::mem_size()...}),
+                sizeof...(TensorIndex));
     }
 
     static constexpr std::size_t access_size()
@@ -58,7 +58,7 @@ struct TensorAntisymmetricIndex
         return std::pair<std::vector<double>, std::vector<std::size_t>>(
                 std::vector<double> {1.},
                 std::vector<std::size_t> {static_cast<std::size_t>(
-                        boost::math::binomial_coefficient<double>(
+                        misc::binomial_coefficient(
                                 std::min({TensorIndex::mem_size()...}),
                                 sizeof...(TensorIndex))
                         - ((sorted_ids[ddc::type_seq_rank_v<
@@ -69,7 +69,7 @@ struct TensorAntisymmetricIndex
                                                                TensorIndex,
                                                                ddc::detail::TypeSeq<TensorIndex...>>
                                     ? 0
-                                    : boost::math::binomial_coefficient<double>(
+                                    : misc::binomial_coefficient(
                                               TensorIndex::mem_size()
                                                       - sorted_ids[ddc::type_seq_rank_v<
                                                               TensorIndex,

--- a/src/tensor/symmetric_tensor.hpp
+++ b/src/tensor/symmetric_tensor.hpp
@@ -5,8 +5,7 @@
 
 #include <ddc/ddc.hpp>
 
-#include <boost/math/special_functions/binomial.hpp>
-
+#include "binomial_coefficient.hpp"
 #include "tensor.hpp"
 
 namespace sil {
@@ -41,7 +40,7 @@ struct TensorSymmetricIndex
 
     static constexpr std::size_t mem_size()
     {
-        return boost::math::binomial_coefficient<double>(
+        return misc::binomial_coefficient(
                 std::min({TensorIndex::mem_size()...}) + sizeof...(TensorIndex) - 1,
                 sizeof...(TensorIndex));
     }
@@ -59,7 +58,7 @@ struct TensorSymmetricIndex
         return std::pair<std::vector<double>, std::vector<std::size_t>>(
                 std::vector<double> {1.},
                 std::vector<std::size_t> {static_cast<std::size_t>(
-                        boost::math::binomial_coefficient<double>(
+                        misc::binomial_coefficient(
                                 std::min({TensorIndex::mem_size()...}) + sizeof...(TensorIndex) - 1,
                                 sizeof...(TensorIndex))
                         - ((sorted_ids[ddc::type_seq_rank_v<
@@ -67,7 +66,7 @@ struct TensorSymmetricIndex
                                     ddc::detail::TypeSeq<TensorIndex...>>]
                                             == TensorIndex::mem_size() - 1
                                     ? 0
-                                    : boost::math::binomial_coefficient<double>(
+                                    : misc::binomial_coefficient(
                                               TensorIndex::mem_size()
                                                       - sorted_ids[ddc::type_seq_rank_v<
                                                               TensorIndex,

--- a/src/tensor/tensor_impl.hpp
+++ b/src/tensor/tensor_impl.hpp
@@ -193,7 +193,7 @@ struct IdFromTypeSeqDims<Index, ddc::DiscreteDomain<Subindex...>, ddc::detail::T
 
 // Returns Index::access_id for the subindex Index of the IndicesTypeSeq
 template <class Index, class IndicesTypeSeq, class... CDim>
-static constexpr std::size_t access_id() // TODO consteval. This is not compile-time atm :/
+static consteval std::size_t access_id()
 {
     if constexpr (TensorNatIndex<Index>) {
         return IdFromTypeSeqDims<
@@ -235,9 +235,7 @@ struct IdFromElem<Index, ddc::DiscreteDomain<Subindex...>>
 };
 
 template <class Index, class IndicesTypeSeq, class... NaturalIndex>
-static constexpr std::size_t access_id(
-        ddc::DiscreteElement<NaturalIndex...>
-                natural_elem) // TODO consteval. This is not compile-time atm :/
+static constexpr std::size_t access_id(ddc::DiscreteElement<NaturalIndex...> natural_elem)
 {
     if constexpr (TensorNatIndex<Index>) {
         return IdFromElem<Index, ddc::DiscreteDomain<Index>>::run(natural_elem);
@@ -271,7 +269,7 @@ public:
     static constexpr discrete_domain_type access_domain();
 
     template <class... CDim>
-    static constexpr discrete_element_type access_element();
+    static consteval discrete_element_type access_element();
 
     template <class... NaturalIndex>
     static constexpr discrete_element_type access_element(
@@ -336,7 +334,7 @@ constexpr TensorAccessor<Index...>::discrete_domain_type TensorAccessor<Index...
 
 template <TensorIndex... Index>
 template <class... CDim>
-constexpr TensorAccessor<Index...>::discrete_element_type TensorAccessor<Index...>::access_element()
+consteval TensorAccessor<Index...>::discrete_element_type TensorAccessor<Index...>::access_element()
 {
     return ddc::DiscreteElement<Index...>(ddc::DiscreteElement<Index>(
             detail::access_id<Index, ddc::detail::TypeSeq<Index...>, CDim...>())...);
@@ -578,7 +576,7 @@ public:
     }
 
     template <class... CDim>
-    KOKKOS_FUNCTION constexpr discrete_element_type access_element()
+    KOKKOS_FUNCTION consteval discrete_element_type access_element()
             const noexcept // TODO merge this with the one below
     {
         return discrete_element_type(accessor_t::template access_element<CDim...>());

--- a/src/young_tableau/young_tableau.hpp
+++ b/src/young_tableau/young_tableau.hpp
@@ -3,9 +3,9 @@
 
 #pragma once
 
-#include <ddc/ddc.hpp>
+#include <iostream>
 
-#include <boost/algorithm/string.hpp>
+#include <ddc/ddc.hpp>
 
 #include "csr.hpp"
 #include "csr_dynamic.hpp"


### PR DESCRIPTION
The version of Tensor::access_element which is templated with continuous dimensions becomes consteval.