### PR TITLE
Cochain iterator

### DIFF
--- a/.devnote
+++ b/.devnote
@@ -15,7 +15,6 @@ SPDX-License-Identifier: GPL-3.0-or-later
 - cochain iterator should give access to a cosimplex, not to the value
 - replace chain_it with value_it
 - usings in tensor tests
-- remove NullVect
 
 ----- CMAKE BASIC COMMAND -----
 

--- a/.devnote
+++ b/.devnote
@@ -12,8 +12,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
 - tests for relabelize_indexes and relabelize_metric
 - Unify TensorAccessor::access_element() functions. Also get<Dims...>() in Tensor ?
 - Consider creating a misc enum for {-1 1} and use it in simplices/chains
-- cochain iterator should give access to a cosimplex, not to the value
-- replace chain_it with value_it
+- replace Cosimplex::operator() with value()
 
 ----- CMAKE BASIC COMMAND -----
 

--- a/.devnote
+++ b/.devnote
@@ -14,7 +14,6 @@ SPDX-License-Identifier: GPL-3.0-or-later
 - Consider creating a misc enum for {-1 1} and use it in simplices/chains
 - cochain iterator should give access to a cosimplex, not to the value
 - replace chain_it with value_it
-- usings in tensor tests
 
 ----- CMAKE BASIC COMMAND -----
 

--- a/.devnote
+++ b/.devnote
@@ -12,7 +12,6 @@ SPDX-License-Identifier: GPL-3.0-or-later
 - tests for relabelize_indexes and relabelize_metric
 - Unify TensorAccessor::access_element() functions. Also get<Dims...>() in Tensor ?
 - Consider creating a misc enum for {-1 1} and use it in simplices/chains
-- replace Cosimplex::operator() with value()
 
 ----- CMAKE BASIC COMMAND -----
 

--- a/src/exterior/chain.hpp
+++ b/src/exterior/chain.hpp
@@ -24,6 +24,7 @@ public:
     using discrete_vector_type = typename simplex_type::discrete_vector_type;
 
 private:
+    static constexpr bool s_is_local = false;
     static constexpr std::size_t s_k = SimplexType::dimension();
     simplices_type m_simplices;
 
@@ -41,6 +42,11 @@ public:
         : m_simplices(simplices)
     {
         assert(check() == 0 && "there are duplicate simplices in the chain");
+    }
+
+    static KOKKOS_FUNCTION constexpr bool is_local() noexcept
+    {
+        return s_is_local;
     }
 
     static KOKKOS_FUNCTION constexpr std::size_t dimension() noexcept
@@ -87,9 +93,19 @@ public:
         assert(check() == 0 && "there are duplicate simplices in the chain");
     }
 
+    KOKKOS_FUNCTION auto begin()
+    {
+        return m_simplices.begin();
+    }
+
     KOKKOS_FUNCTION auto begin() const
     {
         return m_simplices.begin();
+    }
+
+    KOKKOS_FUNCTION auto end()
+    {
+        return m_simplices.end();
     }
 
     KOKKOS_FUNCTION auto end() const

--- a/src/exterior/coboundary.hpp
+++ b/src/exterior/coboundary.hpp
@@ -136,7 +136,7 @@ coboundary(
                 auto cochain = Cochain(chain, coboundary_tensor[elem]);
                 for (auto i = cochain.begin(); i < cochain.end(); ++i) {
                     sil::exterior::Chain simplex_boundary = boundary(
-                            sil::exterior::Simplex(elem, *cochain.chain_it(i))); // TODO simplify
+                            sil::exterior::Simplex(elem, (*i).simplex().discrete_vector()));
                     std::vector<double> values(simplex_boundary.size());
                     for (auto j = simplex_boundary.begin(); j < simplex_boundary.end(); ++j) {
                         values[std::distance(simplex_boundary.begin(), j)]

--- a/src/exterior/coboundary.hpp
+++ b/src/exterior/coboundary.hpp
@@ -135,8 +135,8 @@ coboundary(
                         typename AntisymmetricTensorType::non_indices_domain_t>();
                 auto cochain = Cochain(chain, coboundary_tensor[elem]);
                 for (auto i = cochain.begin(); i < cochain.end(); ++i) {
-                    sil::exterior::Chain simplex_boundary = boundary(
-                            sil::exterior::Simplex(elem, (*i).simplex().discrete_vector()));
+                    sil::exterior::Chain simplex_boundary
+                            = boundary(sil::exterior::Simplex(elem, (*i).discrete_vector()));
                     std::vector<double> values(simplex_boundary.size());
                     for (auto j = simplex_boundary.begin(); j < simplex_boundary.end(); ++j) {
                         values[std::distance(simplex_boundary.begin(), j)]

--- a/src/exterior/cochain.hpp
+++ b/src/exterior/cochain.hpp
@@ -92,6 +92,11 @@ public:
         }
     }
 
+    static KOKKOS_FUNCTION constexpr bool is_local() noexcept
+    {
+        return ChainType::is_local();
+    }
+
     static KOKKOS_FUNCTION constexpr std::size_t dimension() noexcept
     {
         return ChainType::dimension();
@@ -342,10 +347,10 @@ std::ostream& operator<<(std::ostream& out, CochainType const& cochain)
 {
     out << "[\n";
     for (auto i = cochain.begin(); i < cochain.end(); ++i) {
-        if constexpr (misc::Specialization<typename CochainType::chain_type, Chain>) {
-            out << " " << i->simplex() << " : " << i->operator()() << "\n";
-        } else if (misc::Specialization<typename CochainType::chain_type, LocalChain>) {
-            out << " -> " << *cochain.chain_it(i) << " : " << *i << "\n";
+        if constexpr (!cochain.is_local()) {
+            out << " " << (*i).simplex() << " : " << (*i).value() << "\n";
+        } else {
+            out << " -> " << (*i).discrete_vector() << " : " << (*i).value() << "\n";
         }
     }
 

--- a/src/exterior/cochain.hpp
+++ b/src/exterior/cochain.hpp
@@ -191,6 +191,12 @@ public:
     }
 };
 
+/*
+template <
+        class ChainType, misc::Specialization<tensor::Tensor> TensorType>
+Cochain(ChainType&, TensorType) -> Cochain<ChainType, typename TensorType::element_type>;
+*/
+
 template <misc::Specialization<Cochain> CochainType>
 std::ostream& operator<<(std::ostream& out, CochainType const& cochain)
 {

--- a/src/exterior/cochain.hpp
+++ b/src/exterior/cochain.hpp
@@ -165,7 +165,7 @@ public:
         element_type out = 0;
         for (auto i = begin(); i < end(); ++i) {
             if constexpr (misc::Specialization<chain_type, Chain>) {
-                out += ((*i).simplex().negative() ? -1 : 1) * (*i).value();
+                out += ((*i).negative() ? -1 : 1) * (*i).value();
             } else if (misc::Specialization<chain_type, LocalChain>) {
                 out += (m_chain.negative() ? -1 : 1) * (*i).value(); // always false
             }

--- a/src/exterior/cochain.hpp
+++ b/src/exterior/cochain.hpp
@@ -191,12 +191,6 @@ public:
     }
 };
 
-/*
-template <
-        class ChainType, misc::Specialization<tensor::Tensor> TensorType>
-Cochain(ChainType&, TensorType) -> Cochain<ChainType, typename TensorType::element_type>;
-*/
-
 template <misc::Specialization<Cochain> CochainType>
 std::ostream& operator<<(std::ostream& out, CochainType const& cochain)
 {

--- a/src/exterior/cochain.hpp
+++ b/src/exterior/cochain.hpp
@@ -165,9 +165,9 @@ public:
         element_type out = 0;
         for (auto i = begin(); i < end(); ++i) {
             if constexpr (misc::Specialization<chain_type, Chain>) {
-                out += ((*i).simplex().negative() ? -1 : 1) * (*i)();
+                out += ((*i).simplex().negative() ? -1 : 1) * (*i).value();
             } else if (misc::Specialization<chain_type, LocalChain>) {
-                out += (m_chain.negative() ? -1 : 1) * (*i)(); // always false
+                out += (m_chain.negative() ? -1 : 1) * (*i).value(); // always false
             }
         }
         return out;
@@ -178,9 +178,9 @@ public:
         element_type out = 0;
         for (auto i = begin(); i < end(); ++i) {
             if constexpr (misc::Specialization<chain_type, Chain>) {
-                out += ((*i).negative() ? -1 : 1) * (*i)();
+                out += ((*i).negative() ? -1 : 1) * (*i).value();
             } else if (misc::Specialization<chain_type, LocalChain>) {
-                out += (m_chain.negative() ? -1 : 1) * (*i)(); // always false
+                out += (m_chain.negative() ? -1 : 1) * (*i).value(); // always false
             }
         }
         return out;

--- a/src/exterior/cosimplex.hpp
+++ b/src/exterior/cosimplex.hpp
@@ -49,6 +49,36 @@ public:
         return m_simplex;
     }
 
+    KOKKOS_FUNCTION discrete_element_type discrete_element() noexcept
+    {
+        return m_simplex.discrete_element();
+    }
+
+    KOKKOS_FUNCTION discrete_element_type discrete_element() const noexcept
+    {
+        return m_simplex.discrete_element();
+    }
+
+    KOKKOS_FUNCTION discrete_vector_type discrete_vector() noexcept
+    {
+        return m_simplex.discrete_vector();
+    }
+
+    KOKKOS_FUNCTION discrete_vector_type discrete_vector() const noexcept
+    {
+        return m_simplex.discrete_vector();
+    }
+
+    KOKKOS_FUNCTION bool negative() noexcept
+    {
+        return m_simplex.negative();
+    }
+
+    KOKKOS_FUNCTION bool negative() const noexcept
+    {
+        return m_simplex.negative();
+    }
+
     KOKKOS_FUNCTION element_type value() noexcept
     {
         return m_value;

--- a/src/exterior/cosimplex.hpp
+++ b/src/exterior/cosimplex.hpp
@@ -49,12 +49,12 @@ public:
         return m_simplex;
     }
 
-    KOKKOS_FUNCTION element_type operator()() noexcept
+    KOKKOS_FUNCTION element_type value() noexcept
     {
         return m_value;
     }
 
-    KOKKOS_FUNCTION element_type const operator()() const noexcept
+    KOKKOS_FUNCTION element_type const value() const noexcept
     {
         return m_value;
     }
@@ -63,7 +63,7 @@ public:
 template <misc::Specialization<Cosimplex> CosimplexType>
 std::ostream& operator<<(std::ostream& out, CosimplexType const& cosimplex)
 {
-    out << " " << cosimplex.simplex() << ": " << cosimplex() << "\n";
+    out << " " << cosimplex.simplex() << ": " << cosimplex.value() << "\n";
     return out;
 }
 

--- a/src/exterior/local_chain.hpp
+++ b/src/exterior/local_chain.hpp
@@ -41,11 +41,12 @@ public:
     using simplex_type = SimplexType;
     using discrete_element_type = typename simplex_type::discrete_element_type;
     using discrete_vector_type = typename simplex_type::discrete_vector_type;
-    using vects_type = std::vector<discrete_vector_type>;
+    using simplices_type = std::vector<discrete_vector_type>;
 
 private:
+    static constexpr bool s_is_local = true;
     static constexpr std::size_t s_k = SimplexType::dimension();
-    vects_type m_vects;
+    simplices_type m_vects;
 
 public:
     KOKKOS_FUNCTION constexpr explicit LocalChain() noexcept : discrete_element_type {}, m_vects {}
@@ -99,6 +100,11 @@ public:
         assert(check() == 0 && "there are duplicate simplices in the chain");
     }
 
+    static KOKKOS_FUNCTION constexpr bool is_local() noexcept
+    {
+        return s_is_local;
+    }
+
     static KOKKOS_FUNCTION constexpr std::size_t dimension() noexcept
     {
         return s_k;
@@ -131,9 +137,19 @@ public:
         return 0;
     }
 
+    KOKKOS_FUNCTION auto begin()
+    {
+        return m_vects.begin();
+    }
+
     KOKKOS_FUNCTION auto begin() const
     {
         return m_vects.begin();
+    }
+
+    KOKKOS_FUNCTION auto end()
+    {
+        return m_vects.end();
     }
 
     KOKKOS_FUNCTION auto end() const
@@ -165,14 +181,14 @@ public:
 
     KOKKOS_FUNCTION LocalChain<SimplexType> operator+(SimplexType simplex)
     {
-        vects_type vects(m_vects);
+        simplices_type vects(m_vects);
         vects.push_back(simplex.discrete_vector());
         return LocalChain<SimplexType>(vects);
     }
 
     KOKKOS_FUNCTION LocalChain<SimplexType> operator+(LocalChain<SimplexType> simplices_to_add)
     {
-        vects_type vects(m_vects);
+        simplices_type vects(m_vects);
         vects.insert(vects.end(), simplices_to_add.begin(), simplices_to_add.end());
         return LocalChain<SimplexType>(vects);
     }

--- a/tests/exterior/exterior.cpp
+++ b/tests/exterior/exterior.cpp
@@ -430,7 +430,7 @@ TEST(Coboundary, Test)
     sil::exterior::Cochain cochain_boundary(simplex_boundary, 5., 8., 3., 2.);
     sil::exterior::Cosimplex cosimplex = sil::exterior::coboundary(cochain_boundary);
     EXPECT_EQ(cosimplex.simplex(), simplex);
-    EXPECT_EQ(cosimplex(), 4.);
+    EXPECT_EQ(cosimplex.value(), 4.);
 }
 
 TEST(LocalChain, Test)


### PR DESCRIPTION
- Remove iterator on `cochain.m_value `and `chain_it()`
- Create `CochainIterator` class (gives access to `Cosimplex`)
- Use it everywhere