### PR TITLE
Coboundary support scalar and vector

### DIFF
--- a/.devnote
+++ b/.devnote
@@ -13,7 +13,6 @@ SPDX-License-Identifier: GPL-3.0-or-later
 - Unify TensorAccessor::access_element() functions. Also get<Dims...>() in Tensor ?
 - Consider creating a misc enum for {-1 1} and use it in simplices/chains
 - Optional compilation of embed-based modules
-- support scalar and natural vector as forms
 
 ----- CMAKE BASIC COMMAND -----
 

--- a/include/similie/exterior/coboundary.hpp
+++ b/include/similie/exterior/coboundary.hpp
@@ -187,6 +187,7 @@ KOKKOS_FUNCTION coboundary_tensor_t<TagToAddToCochain, CochainTag, TensorType> c
     std::cout << antisymmetric_tensor;
     ddc::parallel_for_each(
             Kokkos::DefaultHostExecutionSpace(),
+            /*
             ddc::remove_dims_of<typename misc::convert_type_seq_to_t<
                     tensor::TensorAntisymmetricIndex,
                     ddc::type_seq_merge_t<
@@ -194,6 +195,8 @@ KOKKOS_FUNCTION coboundary_tensor_t<TagToAddToCochain, CochainTag, TensorType> c
                             misc::to_type_seq_t<
                                     tensor::to_tensor_antisymmetric_index_t<CochainTag>>>>>(
                     antisymmetric_coboundary_tensor.domain()),
+            */
+            antisymmetric_coboundary_tensor.non_indices_domain(),
             [&](auto elem) {
                 auto chain = tangent_basis<
                         CochainTag::rank() + 1,
@@ -229,16 +232,22 @@ KOKKOS_FUNCTION coboundary_tensor_t<TagToAddToCochain, CochainTag, TensorType> c
                     }
                     sil::exterior::Cochain<decltype(simplex_boundary)>
                             cochain_boundary(simplex_boundary, values);
-                    antisymmetric_coboundary_tensor
-                            .mem(elem,
-                                 ddc::DiscreteElement<typename misc::convert_type_seq_to_t<
-                                         tensor::TensorAntisymmetricIndex,
-                                         ddc::type_seq_merge_t<
-                                                 ddc::detail::TypeSeq<TagToAddToCochain>,
-                                                 misc::to_type_seq_t<
-                                                         tensor::to_tensor_antisymmetric_index_t<
-                                                                 CochainTag>>>>>(
-                                         std::distance(cochain.begin(), i)))
+                    antisymmetric_coboundary_tensor.mem(
+                            elem,
+                            ddc::DiscreteElement<typename misc::convert_type_seq_to_t<
+                                    tensor::TensorAntisymmetricIndex,
+                                    ddc::type_seq_remove_t<
+                                            ddc::type_seq_merge_t<
+                                                    misc::to_type_seq_t<
+                                                            tensor::to_tensor_antisymmetric_index_t<
+                                                                    TagToAddToCochain>>,
+                                                    misc::to_type_seq_t<
+                                                            tensor::to_tensor_antisymmetric_index_t<
+                                                                    CochainTag>>>,
+                                            ddc::detail::TypeSeq<
+                                                    tensor::TensorNaturalIndex<>,
+                                                    tensor::TensorAntisymmetricIndex<>>>>>(
+                                    std::distance(cochain.begin(), i)))
                             = cochain_boundary.integrate();
                 }
             });

--- a/include/similie/exterior/coboundary.hpp
+++ b/include/similie/exterior/coboundary.hpp
@@ -184,7 +184,6 @@ KOKKOS_FUNCTION coboundary_tensor_t<TagToAddToCochain, CochainTag, TensorType> c
                     tensor::to_tensor_antisymmetric_index_t<TagToAddToCochain>,
                     tensor::to_tensor_antisymmetric_index_t<CochainTag>>>(tensor);
 
-    std::cout << antisymmetric_tensor;
     ddc::parallel_for_each(
             Kokkos::DefaultHostExecutionSpace(),
             ddc::remove_dims_of<typename misc::convert_type_seq_to_t<

--- a/include/similie/exterior/coboundary.hpp
+++ b/include/similie/exterior/coboundary.hpp
@@ -187,16 +187,18 @@ KOKKOS_FUNCTION coboundary_tensor_t<TagToAddToCochain, CochainTag, TensorType> c
     std::cout << antisymmetric_tensor;
     ddc::parallel_for_each(
             Kokkos::DefaultHostExecutionSpace(),
-            /*
             ddc::remove_dims_of<typename misc::convert_type_seq_to_t<
                     tensor::TensorAntisymmetricIndex,
-                    ddc::type_seq_merge_t<
-                            ddc::detail::TypeSeq<TagToAddToCochain>,
-                            misc::to_type_seq_t<
-                                    tensor::to_tensor_antisymmetric_index_t<CochainTag>>>>>(
+                    ddc::type_seq_remove_t<
+                            ddc::type_seq_merge_t<
+                                    misc::to_type_seq_t<tensor::to_tensor_antisymmetric_index_t<
+                                            TagToAddToCochain>>,
+                                    misc::to_type_seq_t<
+                                            tensor::to_tensor_antisymmetric_index_t<CochainTag>>>,
+                            ddc::detail::TypeSeq<
+                                    tensor::TensorNaturalIndex<>,
+                                    tensor::TensorAntisymmetricIndex<>>>>>(
                     antisymmetric_coboundary_tensor.domain()),
-            */
-            antisymmetric_coboundary_tensor.non_indices_domain(),
             [&](auto elem) {
                 auto chain = tangent_basis<
                         CochainTag::rank() + 1,

--- a/include/similie/misc/type_seq_conversion.hpp
+++ b/include/similie/misc/type_seq_conversion.hpp
@@ -17,10 +17,10 @@ struct ToTypeSeq
     using type = ddc::detail::TypeSeq<>;
 };
 
-template <template <class...> class T, class HeadArg, class... Arg>
-struct ToTypeSeq<T<HeadArg, Arg...>>
+template <template <class...> class T, class... Arg>
+struct ToTypeSeq<T<Arg...>>
 {
-    using type = ddc::detail::TypeSeq<HeadArg, Arg...>;
+    using type = ddc::detail::TypeSeq<Arg...>;
 };
 
 } // namespace detail

--- a/include/similie/misc/type_seq_conversion.hpp
+++ b/include/similie/misc/type_seq_conversion.hpp
@@ -17,10 +17,10 @@ struct ToTypeSeq
     using type = ddc::detail::TypeSeq<>;
 };
 
-template <template <class...> class T, class... Arg>
-struct ToTypeSeq<T<Arg...>>
+template <template <class...> class T, class HeadArg, class... Arg>
+struct ToTypeSeq<T<HeadArg, Arg...>>
 {
-    using type = ddc::detail::TypeSeq<Arg...>;
+    using type = ddc::detail::TypeSeq<HeadArg, Arg...>;
 };
 
 } // namespace detail

--- a/include/similie/misc/type_seq_conversion.hpp
+++ b/include/similie/misc/type_seq_conversion.hpp
@@ -12,7 +12,10 @@ namespace misc {
 namespace detail {
 
 template <class T>
-struct ToTypeSeq;
+struct ToTypeSeq
+{
+    using type = ddc::detail::TypeSeq<>;
+};
 
 template <template <class...> class T, class... Arg>
 struct ToTypeSeq<T<Arg...>>

--- a/include/similie/tensor/antisymmetric_tensor.hpp
+++ b/include/similie/tensor/antisymmetric_tensor.hpp
@@ -173,6 +173,14 @@ template <class T>
 struct ToTensorAntisymmetricIndex;
 
 template <tensor::TensorNatIndex Index>
+    requires(Index::size() == 0)
+struct ToTensorAntisymmetricIndex<Index>
+{
+    using type = TensorAntisymmetricIndex<>;
+};
+
+template <tensor::TensorNatIndex Index>
+    requires(Index::size() > 0)
 struct ToTensorAntisymmetricIndex<Index>
 {
     using type = TensorAntisymmetricIndex<Index>;

--- a/include/similie/tensor/antisymmetric_tensor.hpp
+++ b/include/similie/tensor/antisymmetric_tensor.hpp
@@ -6,6 +6,7 @@
 #include <ddc/ddc.hpp>
 
 #include <similie/misc/binomial_coefficient.hpp>
+#include <similie/misc/specialization.hpp>
 
 #include "tensor_impl.hpp"
 
@@ -165,6 +166,28 @@ public:
         }
     }
 };
+
+namespace detail {
+
+template <class T>
+struct ToTensorAntisymmetricIndex;
+
+template <tensor::TensorNatIndex Index>
+struct ToTensorAntisymmetricIndex<Index>
+{
+    using type = TensorAntisymmetricIndex<Index>;
+};
+
+template <tensor::TensorNatIndex... Index>
+struct ToTensorAntisymmetricIndex<TensorAntisymmetricIndex<Index...>>
+{
+    using type = TensorAntisymmetricIndex<Index...>;
+};
+
+} // namespace detail
+
+template <class T>
+using to_tensor_antisymmetric_index_t = typename detail::ToTensorAntisymmetricIndex<T>::type;
 
 } // namespace tensor
 

--- a/include/similie/tensor/tensor_impl.hpp
+++ b/include/similie/tensor/tensor_impl.hpp
@@ -29,12 +29,16 @@ struct TensorNaturalIndex
 
     static constexpr std::size_t rank()
     {
-        return 1;
+        return sizeof...(CDim) != 0;
     }
 
     static constexpr std::size_t size()
     {
-        return sizeof...(CDim);
+        if constexpr (rank() == 0) {
+            return 1;
+        } else {
+            return sizeof...(CDim);
+        }
     }
 
     static constexpr std::size_t mem_size()
@@ -50,9 +54,16 @@ struct TensorNaturalIndex
     template <class ODim>
     static constexpr std::pair<std::vector<double>, std::vector<std::size_t>> mem_lin_comb()
     {
-        return std::pair<std::vector<double>, std::vector<std::size_t>>(
-                std::vector<double> {1.},
-                std::vector<std::size_t> {ddc::type_seq_rank_v<ODim, type_seq_dimensions>});
+        if constexpr (rank() == 0) {
+            return std::pair<
+                    std::vector<double>,
+                    std::vector<
+                            std::size_t>>(std::vector<double> {1.}, std::vector<std::size_t> {0});
+        } else {
+            return std::pair<std::vector<double>, std::vector<std::size_t>>(
+                    std::vector<double> {1.},
+                    std::vector<std::size_t> {ddc::type_seq_rank_v<ODim, type_seq_dimensions>});
+        }
     }
 
     static constexpr std::pair<std::vector<double>, std::vector<std::size_t>> mem_lin_comb(

--- a/include/similie/tensor/tensor_impl.hpp
+++ b/include/similie/tensor/tensor_impl.hpp
@@ -663,8 +663,11 @@ public:
 
 // Relabelize index without altering allocation
 namespace detail {
-template <class IndexToRelabelize, TensorNatIndex OldIndex, TensorNatIndex NewIndex>
-struct RelabelizeIndex
+template <class IndexToRelabelize, class OldIndex, class NewIndex>
+struct RelabelizeIndex;
+
+template <class IndexToRelabelize, TensorIndex OldIndex, TensorIndex NewIndex>
+struct RelabelizeIndex<IndexToRelabelize, OldIndex, NewIndex>
 {
     using type = std::
             conditional_t<std::is_same_v<IndexToRelabelize, OldIndex>, NewIndex, IndexToRelabelize>;
@@ -673,8 +676,8 @@ struct RelabelizeIndex
 template <
         template <class...>
         class IndexToRelabelizeType,
-        class OldIndex,
-        class NewIndex,
+        TensorNatIndex OldIndex,
+        TensorNatIndex NewIndex,
         class... Arg>
 struct RelabelizeIndex<IndexToRelabelizeType<Arg...>, OldIndex, NewIndex>
 {
@@ -686,6 +689,21 @@ struct RelabelizeIndex<IndexToRelabelizeType<Arg...>, OldIndex, NewIndex>
                     IndexToRelabelizeType<Arg...>>,
             IndexToRelabelizeType<
                     std::conditional_t<std::is_same_v<Arg, OldIndex>, NewIndex, Arg>...>>;
+};
+
+template <
+        template <class...>
+        class IndexToRelabelizeType,
+        TensorIndex OldIndex,
+        TensorIndex NewIndex,
+        class... Arg>
+    requires(!TensorNatIndex<OldIndex> && !TensorNatIndex<NewIndex>)
+struct RelabelizeIndex<IndexToRelabelizeType<Arg...>, OldIndex, NewIndex>
+{
+    using type = std::conditional_t<
+            std::is_same_v<IndexToRelabelizeType<Arg...>, OldIndex>,
+            NewIndex,
+            IndexToRelabelizeType<Arg...>>;
 };
 
 template <class Dom, class OldIndex, class NewIndex>

--- a/tests/exterior/derivative.cpp
+++ b/tests/exterior/derivative.cpp
@@ -54,13 +54,17 @@ static auto test_derivative()
                 Kokkos::layout_right,
                 Kokkos::DefaultHostExecutionSpace::memory_space>
                 derivative(derivative_alloc);
-        sil::exterior::deriv<
-                ddc::type_seq_element_t<
-                        0,
-                        ddc::type_seq_remove_t<
-                                sil::misc::to_type_seq_t<OutIndex>,
-                                sil::misc::to_type_seq_t<InIndex>>>,
-                InIndex>(derivative, tensor);
+        if constexpr (sil::tensor::TensorNatIndex<OutIndex>) {
+            sil::exterior::deriv<OutIndex, InIndex>(derivative, tensor);
+        } else {
+            sil::exterior::deriv<
+                    ddc::type_seq_element_t<
+                            0,
+                            ddc::type_seq_remove_t<
+                                    sil::misc::to_type_seq_t<OutIndex>,
+                                    sil::misc::to_type_seq_t<InIndex>>>,
+                    InIndex>(derivative, tensor);
+        }
         return std::make_pair(std::move(derivative_alloc), derivative);
     } else {
         ddc::DiscreteDomain<DDim..., InIndex>
@@ -101,13 +105,17 @@ static auto test_derivative()
                 Kokkos::layout_right,
                 Kokkos::DefaultHostExecutionSpace::memory_space>
                 derivative(derivative_alloc);
-        sil::exterior::deriv<
-                ddc::type_seq_element_t<
-                        0,
-                        ddc::type_seq_remove_t<
-                                sil::misc::to_type_seq_t<OutIndex>,
-                                sil::misc::to_type_seq_t<InIndex>>>,
-                InIndex>(derivative, tensor);
+        if constexpr (sil::tensor::TensorNatIndex<OutIndex>) {
+            sil::exterior::deriv<OutIndex, InIndex>(derivative, tensor);
+        } else {
+            sil::exterior::deriv<
+                    ddc::type_seq_element_t<
+                            0,
+                            ddc::type_seq_remove_t<
+                                    sil::misc::to_type_seq_t<OutIndex>,
+                                    sil::misc::to_type_seq_t<InIndex>>>,
+                    InIndex>(derivative, tensor);
+        }
         return std::make_pair(std::move(derivative_alloc), derivative);
     }
 }
@@ -202,7 +210,6 @@ TEST(ExteriorDerivative, 2DGradient)
             sil::tensor::TensorAntisymmetricIndex<Mu2>,
             DDimX,
             DDimY>();
-    std::cout << derivative;
     EXPECT_EQ(
             derivative(
                     ddc::DiscreteElement<DDimX, DDimY> {0, 0},
@@ -294,13 +301,8 @@ TEST(ExteriorDerivative, 2DGradient)
                     derivative.accessor().access_element<Y>()),
             0.);
 
-    auto [alloc2, derivative2] = test_derivative<
-            3,
-            true,
-            sil::tensor::TensorAntisymmetricIndex<>,
-            sil::tensor::TensorAntisymmetricIndex<Mu2>,
-            DDimX,
-            DDimY>();
+    auto [alloc2, derivative2]
+            = test_derivative<3, true, sil::tensor::TensorNaturalIndex<>, Mu2, DDimX, DDimY>();
     EXPECT_EQ(
             derivative2(
                     ddc::DiscreteElement<DDimX, DDimY> {0, 0},
@@ -430,7 +432,7 @@ TEST(ExteriorDerivative, 2DRotational)
     auto [alloc2, derivative2] = test_derivative<
             3,
             true,
-            sil::tensor::TensorAntisymmetricIndex<Mu2>,
+            Mu2,
             sil::tensor::TensorAntisymmetricIndex<Nu2, Mu2>,
             DDimX,
             DDimY>();


### PR DESCRIPTION
Support rank 0 or 1 `TensorNaturalIndex` seen as scalar and vector by coboundary operator.