### PR TITLE
Derivative with spectator dim and index

### DIFF
--- a/include/similie/exterior/coboundary.hpp
+++ b/include/similie/exterior/coboundary.hpp
@@ -281,7 +281,6 @@ KOKKOS_FUNCTION coboundary_tensor_t<TagToAddToCochain, CochainTag, TensorType> c
 template <
         tensor::TensorNatIndex TagToAddToCochain,
         tensor::TensorIndex CochainTag,
-
         misc::Specialization<tensor::Tensor> TensorType>
 KOKKOS_FUNCTION coboundary_tensor_t<TagToAddToCochain, CochainTag, TensorType> deriv(
         coboundary_tensor_t<TagToAddToCochain, CochainTag, TensorType> coboundary_tensor,

--- a/include/similie/exterior/coboundary.hpp
+++ b/include/similie/exterior/coboundary.hpp
@@ -186,9 +186,7 @@ struct NonSpectatorDimension<Index, ddc::DiscreteDomain<DDim...>>
 template <
         tensor::TensorNatIndex TagToAddToCochain,
         tensor::TensorIndex CochainTag,
-
-        misc::Specialization<tensor::Tensor> TensorType,
-        class... ODDim>
+        misc::Specialization<tensor::Tensor> TensorType>
 KOKKOS_FUNCTION coboundary_tensor_t<TagToAddToCochain, CochainTag, TensorType> coboundary(
         coboundary_tensor_t<TagToAddToCochain, CochainTag, TensorType> coboundary_tensor,
         TensorType tensor)
@@ -284,8 +282,7 @@ template <
         tensor::TensorNatIndex TagToAddToCochain,
         tensor::TensorIndex CochainTag,
 
-        misc::Specialization<tensor::Tensor> TensorType,
-        class... ODDim>
+        misc::Specialization<tensor::Tensor> TensorType>
 KOKKOS_FUNCTION coboundary_tensor_t<TagToAddToCochain, CochainTag, TensorType> deriv(
         coboundary_tensor_t<TagToAddToCochain, CochainTag, TensorType> coboundary_tensor,
         TensorType tensor)
@@ -293,8 +290,7 @@ KOKKOS_FUNCTION coboundary_tensor_t<TagToAddToCochain, CochainTag, TensorType> d
     return coboundary<
             TagToAddToCochain,
             CochainTag,
-            TensorType,
-            ODDim...>(coboundary_tensor, tensor);
+            TensorType>(coboundary_tensor, tensor);
 }
 
 } // namespace exterior

--- a/include/similie/exterior/coboundary.hpp
+++ b/include/similie/exterior/coboundary.hpp
@@ -286,10 +286,7 @@ KOKKOS_FUNCTION coboundary_tensor_t<TagToAddToCochain, CochainTag, TensorType> d
         coboundary_tensor_t<TagToAddToCochain, CochainTag, TensorType> coboundary_tensor,
         TensorType tensor)
 {
-    return coboundary<
-            TagToAddToCochain,
-            CochainTag,
-            TensorType>(coboundary_tensor, tensor);
+    return coboundary<TagToAddToCochain, CochainTag, TensorType>(coboundary_tensor, tensor);
 }
 
 } // namespace exterior

--- a/include/similie/exterior/coboundary.hpp
+++ b/include/similie/exterior/coboundary.hpp
@@ -168,7 +168,9 @@ KOKKOS_FUNCTION coboundary_t<CochainType> coboundary(
 template <
         tensor::TensorNatIndex TagToAddToCochain,
         tensor::TensorIndex CochainTag,
-        misc::Specialization<tensor::Tensor> TensorType>
+
+        misc::Specialization<tensor::Tensor> TensorType,
+        class... ODDim>
 KOKKOS_FUNCTION coboundary_tensor_t<TagToAddToCochain, CochainTag, TensorType> coboundary(
         coboundary_tensor_t<TagToAddToCochain, CochainTag, TensorType> coboundary_tensor,
         TensorType tensor)
@@ -199,12 +201,9 @@ KOKKOS_FUNCTION coboundary_tensor_t<TagToAddToCochain, CochainTag, TensorType> c
                                     tensor::TensorAntisymmetricIndex<>>>>>(
                     antisymmetric_coboundary_tensor.domain()),
             [&](auto elem) {
-                auto chain = tangent_basis<
-                        CochainTag::rank() + 1,
-                        typename TensorType::non_indices_domain_t>();
-                auto lower_chain = tangent_basis<
-                        CochainTag::rank(),
-                        typename TensorType::non_indices_domain_t>();
+                auto chain = tangent_basis<CochainTag::rank() + 1, ddc::DiscreteDomain<ODDim...>>();
+                auto lower_chain
+                        = tangent_basis<CochainTag::rank(), ddc::DiscreteDomain<ODDim...>>();
                 auto cochain = Cochain(chain, antisymmetric_coboundary_tensor[elem]);
                 for (auto i = cochain.begin(); i < cochain.end(); ++i) {
                     sil::exterior::Chain simplex_boundary
@@ -259,12 +258,18 @@ KOKKOS_FUNCTION coboundary_tensor_t<TagToAddToCochain, CochainTag, TensorType> c
 template <
         tensor::TensorNatIndex TagToAddToCochain,
         tensor::TensorIndex CochainTag,
-        misc::Specialization<tensor::Tensor> TensorType>
+
+        misc::Specialization<tensor::Tensor> TensorType,
+        class... ODDim>
 KOKKOS_FUNCTION coboundary_tensor_t<TagToAddToCochain, CochainTag, TensorType> deriv(
         coboundary_tensor_t<TagToAddToCochain, CochainTag, TensorType> coboundary_tensor,
         TensorType tensor)
 {
-    return coboundary<TagToAddToCochain, CochainTag, TensorType>(coboundary_tensor, tensor);
+    return coboundary<
+            TagToAddToCochain,
+            CochainTag,
+            TensorType,
+            ODDim...>(coboundary_tensor, tensor);
 }
 
 } // namespace exterior

--- a/tests/exterior/derivative.cpp
+++ b/tests/exterior/derivative.cpp
@@ -56,7 +56,7 @@ static auto test_derivative()
                 Kokkos::DefaultHostExecutionSpace::memory_space>
                 derivative(derivative_alloc);
         if constexpr (sil::tensor::TensorNatIndex<OutIndex>) {
-            sil::exterior::deriv<OutIndex, InIndex, decltype(tensor), DDim...>(derivative, tensor);
+            sil::exterior::deriv<OutIndex, InIndex>(derivative, tensor);
         } else {
             sil::exterior::deriv<
                     ddc::type_seq_element_t<
@@ -64,9 +64,7 @@ static auto test_derivative()
                             ddc::type_seq_remove_t<
                                     sil::misc::to_type_seq_t<OutIndex>,
                                     sil::misc::to_type_seq_t<InIndex>>>,
-                    InIndex,
-                    decltype(tensor),
-                    DDim...>(derivative, tensor);
+                    InIndex>(derivative, tensor);
         }
         return std::make_pair(std::move(derivative_alloc), derivative);
     } else {
@@ -109,7 +107,7 @@ static auto test_derivative()
                 Kokkos::DefaultHostExecutionSpace::memory_space>
                 derivative(derivative_alloc);
         if constexpr (sil::tensor::TensorNatIndex<OutIndex>) {
-            sil::exterior::deriv<OutIndex, InIndex, decltype(tensor), DDim...>(derivative, tensor);
+            sil::exterior::deriv<OutIndex, InIndex>(derivative, tensor);
         } else {
             sil::exterior::deriv<
                     ddc::type_seq_element_t<
@@ -117,9 +115,7 @@ static auto test_derivative()
                             ddc::type_seq_remove_t<
                                     sil::misc::to_type_seq_t<OutIndex>,
                                     sil::misc::to_type_seq_t<InIndex>>>,
-                    InIndex,
-                    decltype(tensor),
-                    DDim...>(derivative, tensor);
+                    InIndex>(derivative, tensor);
         }
         return std::make_pair(std::move(derivative_alloc), derivative);
     }
@@ -988,12 +984,7 @@ TEST(ExteriorDerivative, 2DRotationalWithSpects)
             Kokkos::layout_right,
             Kokkos::DefaultHostExecutionSpace::memory_space>
             derivative(derivative_alloc);
-    sil::exterior::deriv<
-            Nu2,
-            sil::tensor::TensorAntisymmetricIndex<Mu2>,
-            decltype(tensor),
-            DDimX,
-            DDimY>(derivative, tensor);
+    sil::exterior::deriv<Nu2, sil::tensor::TensorAntisymmetricIndex<Mu2>>(derivative, tensor);
 
     for (auto dim_spect_elem : ddc::DiscreteDomain<DDimSpect>(tensor.mem_domain())) {
         for (auto index_spect_elem : ddc::DiscreteDomain<IndexSpect>(tensor.mem_domain())) {

--- a/tests/exterior/derivative.cpp
+++ b/tests/exterior/derivative.cpp
@@ -6,6 +6,7 @@
 #include <ddc/ddc.hpp>
 
 #include <gtest/gtest.h>
+#include <similie/tensor/symmetric_tensor.hpp>
 
 #include "exterior.hpp"
 #include "filled_struct.hpp"
@@ -889,4 +890,121 @@ TEST(ExteriorDerivative, 4DHyperDivergency)
             DDimX,
             DDimY,
             DDimZ>();
+}
+
+/*
+struct IndexSpect : ddc::UniformPointSampling<T>
+{
+};
+*/
+
+struct SpectNatIndex1 : sil::tensor::TensorNaturalIndex<T, X, Y, Z>
+{
+};
+
+struct SpectNatIndex2 : sil::tensor::TensorNaturalIndex<T, X, Y, Z>
+{
+};
+
+struct IndexSpect : sil::tensor::TensorSymmetricIndex<SpectNatIndex1, SpectNatIndex2>
+{
+};
+
+TEST(ExteriorDerivative, 2DRotationalWithSpects)
+{
+    const std::size_t N = 3;
+    sil::tensor::TensorAccessor<IndexSpect, sil::tensor::TensorAntisymmetricIndex<Mu2>>
+            tensor_accessor;
+    ddc::DiscreteDomain<sil::tensor::TensorAntisymmetricIndex<Mu2>, DDimX, IndexSpect, DDimY>
+            dom(tensor_accessor.mem_domain(),
+                ddc::DiscreteDomain(
+                        sil::misc::filled_struct<ddc::DiscreteElement<DDimX, DDimY>>(0),
+                        sil::misc::filled_struct<ddc::DiscreteVector<DDimX, DDimY>>(N)));
+    ddc::Chunk tensor_alloc(dom, ddc::HostAllocator<double>());
+    sil::tensor::Tensor<
+            double,
+            ddc::DiscreteDomain<
+                    sil::tensor::TensorAntisymmetricIndex<Mu2>,
+                    DDimX,
+                    IndexSpect,
+                    DDimY>,
+            Kokkos::layout_right,
+            Kokkos::DefaultHostExecutionSpace::memory_space>
+            tensor(tensor_alloc);
+    for (std::size_t i = 0; i < sil::tensor::TensorAntisymmetricIndex<Mu2>::mem_size(); ++i) {
+        ddc::parallel_for_each(
+                Kokkos::DefaultHostExecutionSpace(),
+                ddc::DiscreteDomain<DDimX, IndexSpect, DDimY>(tensor.domain()),
+                [&](auto elem) {
+                    tensor
+                            .mem(elem,
+                                 ddc::DiscreteElement<sil::tensor::TensorAntisymmetricIndex<Mu2>>(
+                                         i))
+                            = i + 1.;
+                });
+        for (std::size_t j = 0; j < IndexSpect::mem_size(); ++j) {
+            tensor
+                    .mem(sil::misc::filled_struct<ddc::DiscreteElement<DDimX, DDimY>>(1),
+                         ddc::DiscreteElement<sil::tensor::TensorAntisymmetricIndex<Mu2>>(i),
+                         ddc::DiscreteElement<IndexSpect>(j))
+                    = i + 2.;
+        }
+    }
+    sil::tensor::TensorAccessor<IndexSpect, sil::tensor::TensorAntisymmetricIndex<Nu2, Mu2>>
+            derivative_accessor;
+    ddc::DiscreteDomain<sil::tensor::TensorAntisymmetricIndex<Nu2, Mu2>, DDimX, IndexSpect, DDimY>
+            derivative_dom(
+                    derivative_accessor.mem_domain(),
+                    ddc::DiscreteDomain(
+                            sil::misc::filled_struct<
+                                    ddc::DiscreteElement<DDimX, DDimY>>(0),
+                            sil::misc::filled_struct<ddc::DiscreteVector<DDimX, DDimY>>(
+                                    2)));
+    ddc::Chunk derivative_alloc(derivative_dom, ddc::HostAllocator<double>());
+    sil::tensor::Tensor<
+            double,
+            ddc::DiscreteDomain<
+                    sil::tensor::TensorAntisymmetricIndex<Nu2, Mu2>,
+                    DDimX,
+                    IndexSpect,
+                    DDimY>,
+            Kokkos::layout_right,
+            Kokkos::DefaultHostExecutionSpace::memory_space>
+            derivative(derivative_alloc);
+    sil::exterior::deriv<Nu2, sil::tensor::TensorAntisymmetricIndex<Mu2>>(derivative, tensor);
+    std::cout << derivative;
+    for (auto i : ddc::DiscreteDomain<IndexSpect>(derivative.mem_domain())) {
+        EXPECT_EQ(
+                derivative(
+                        ddc::DiscreteElement<DDimX, DDimY> {0, 0},
+                        i,
+                        sil::tensor::TensorAccessor<
+                                sil::tensor::TensorAntisymmetricIndex<Nu2, Mu2>>::
+                                access_element<X, Y>()),
+                0.);
+        EXPECT_EQ(
+                derivative(
+                        ddc::DiscreteElement<DDimX, DDimY> {1, 0},
+                        i,
+                        sil::tensor::TensorAccessor<
+                                sil::tensor::TensorAntisymmetricIndex<Nu2, Mu2>>::
+                                access_element<X, Y>()),
+                -1.);
+        EXPECT_EQ(
+                derivative(
+                        ddc::DiscreteElement<DDimX, DDimY> {0, 1},
+                        i,
+                        sil::tensor::TensorAccessor<
+                                sil::tensor::TensorAntisymmetricIndex<Nu2, Mu2>>::
+                                access_element<X, Y>()),
+                1.);
+        EXPECT_EQ(
+                derivative(
+                        ddc::DiscreteElement<DDimX, DDimY> {1, 1},
+                        i,
+                        sil::tensor::TensorAccessor<
+                                sil::tensor::TensorAntisymmetricIndex<Nu2, Mu2>>::
+                                access_element<X, Y>()),
+                0.);
+    }
 }


### PR DESCRIPTION
Support and test the computation of rotational along (X, Y) faces every of components of a symmetric tensor in a (T, X, Y) space.