### PR TITLE
Character in metric indexing

### DIFF
--- a/.devnote
+++ b/.devnote
@@ -14,6 +14,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
 - Consider creating a misc enum for {-1 1} and use it in simplices/chains
 - Optional compilation of embed-based modules
 - enforced_deep_copy (avoid call to Kokkos::deep_copy)
+- Rename TensorCovariantTensorIndex -> Covariant
 
 ----- CMAKE BASIC COMMAND -----
 

--- a/examples/kretschmann_scalar.cpp
+++ b/examples/kretschmann_scalar.cpp
@@ -31,8 +31,8 @@ struct Z
 // Declare the Minkowski metric as a Lorentzian signature (-, +, +, +)
 using MetricIndex = sil::tensor::TensorLorentzianSignIndex<
         std::integral_constant<std::size_t, 1>,
-        sil::tensor::MetricIndex1<T, X, Y, Z>,
-        sil::tensor::MetricIndex2<T, X, Y, Z>>;
+        sil::tensor::TensorCovariantNaturalIndex<sil::tensor::MetricIndex1<T, X, Y, Z>>,
+        sil::tensor::TensorCovariantNaturalIndex<sil::tensor::MetricIndex2<T, X, Y, Z>>>;
 
 // Declare natural indices taking values in {T, X, Y, Z}
 struct Mu : sil::tensor::TensorNaturalIndex<T, X, Y, Z>

--- a/include/similie/exterior/coboundary.hpp
+++ b/include/similie/exterior/coboundary.hpp
@@ -62,74 +62,25 @@ struct CoboundaryTensorType;
 
 template <
         tensor::TensorNatIndex TagToAddToCochain,
+        tensor::TensorIndex CochainIndex,
         class ElementType,
         class... DDim,
         class SupportType,
         class MemorySpace>
 struct CoboundaryTensorType<
         TagToAddToCochain,
-        tensor::TensorNaturalIndex<>,
+        CochainIndex,
         tensor::Tensor<ElementType, ddc::DiscreteDomain<DDim...>, SupportType, MemorySpace>>
 {
     static_assert(ddc::type_seq_contains_v<
-                  ddc::detail::TypeSeq<tensor::TensorNaturalIndex<>>,
+                  ddc::detail::TypeSeq<CochainIndex>,
                   ddc::detail::TypeSeq<DDim...>>);
     using type = tensor::Tensor<
             ElementType,
             ddc::replace_dim_of_t<
                     ddc::DiscreteDomain<DDim...>,
-                    tensor::TensorNaturalIndex<>,
-                    TagToAddToCochain>,
-            SupportType,
-            MemorySpace>;
-};
-
-template <
-        tensor::TensorNatIndex TagToAddToCochain,
-        tensor::TensorNatIndex NaturalCochainTag,
-        class ElementType,
-        class... DDim,
-        class SupportType,
-        class MemorySpace>
-struct CoboundaryTensorType<
-        TagToAddToCochain,
-        NaturalCochainTag,
-        tensor::Tensor<ElementType, ddc::DiscreteDomain<DDim...>, SupportType, MemorySpace>>
-{
-    static_assert(ddc::type_seq_contains_v<
-                  ddc::detail::TypeSeq<NaturalCochainTag>,
-                  ddc::detail::TypeSeq<DDim...>>);
-    using type = tensor::Tensor<
-            ElementType,
-            ddc::replace_dim_of_t<
-                    ddc::DiscreteDomain<DDim...>,
-                    NaturalCochainTag,
-                    tensor::TensorAntisymmetricIndex<TagToAddToCochain, NaturalCochainTag>>,
-            SupportType,
-            MemorySpace>;
-};
-
-template <
-        tensor::TensorNatIndex TagToAddToCochain,
-        tensor::TensorNatIndex... NaturalCochainTag,
-        class ElementType,
-        class... DDim,
-        class SupportType,
-        class MemorySpace>
-struct CoboundaryTensorType<
-        TagToAddToCochain,
-        tensor::TensorAntisymmetricIndex<NaturalCochainTag...>,
-        tensor::Tensor<ElementType, ddc::DiscreteDomain<DDim...>, SupportType, MemorySpace>>
-{
-    static_assert(ddc::type_seq_contains_v<
-                  ddc::detail::TypeSeq<tensor::TensorAntisymmetricIndex<NaturalCochainTag...>>,
-                  ddc::detail::TypeSeq<DDim...>>);
-    using type = tensor::Tensor<
-            ElementType,
-            ddc::replace_dim_of_t<
-                    ddc::DiscreteDomain<DDim...>,
-                    tensor::TensorAntisymmetricIndex<NaturalCochainTag...>,
-                    tensor::TensorAntisymmetricIndex<TagToAddToCochain, NaturalCochainTag...>>,
+                    CochainIndex,
+                    typename CoboundaryIndex<TagToAddToCochain, CochainIndex>::type>,
             SupportType,
             MemorySpace>;
 };

--- a/include/similie/exterior/coboundary.hpp
+++ b/include/similie/exterior/coboundary.hpp
@@ -175,10 +175,8 @@ KOKKOS_FUNCTION coboundary_tensor_t<TagToAddToCochain, CochainTag, TensorType> c
 {
     ddc::parallel_for_each(
             Kokkos::DefaultHostExecutionSpace(),
-            ddc::remove_dims_of_t<
-                    typename coboundary_tensor_t<TagToAddToCochain, CochainTag, TensorType>::
-                            discrete_domain_type,
-                    coboundary_index_t<TagToAddToCochain, CochainTag>>(coboundary_tensor.domain()),
+            ddc::remove_dims_of<coboundary_index_t<TagToAddToCochain, CochainTag>>(
+                    coboundary_tensor.domain()),
             [&](auto elem) {
                 auto chain = tangent_basis<
                         CochainTag::rank() + 1,

--- a/include/similie/tensor/antisymmetric_tensor.hpp
+++ b/include/similie/tensor/antisymmetric_tensor.hpp
@@ -173,14 +173,14 @@ template <class T>
 struct ToTensorAntisymmetricIndex;
 
 template <tensor::TensorNatIndex Index>
-    requires(Index::size() == 0)
+    requires(Index::rank() == 0)
 struct ToTensorAntisymmetricIndex<Index>
 {
     using type = TensorAntisymmetricIndex<>;
 };
 
 template <tensor::TensorNatIndex Index>
-    requires(Index::size() > 0)
+    requires(Index::rank() > 0)
 struct ToTensorAntisymmetricIndex<Index>
 {
     using type = TensorAntisymmetricIndex<Index>;

--- a/include/similie/tensor/metric.hpp
+++ b/include/similie/tensor/metric.hpp
@@ -58,7 +58,7 @@ using relabelize_metric_in_domain_t = relabelize_indices_in_domain_t<
                         typename Index1::type_seq_dimensions>::type,
                 typename detail::ConvertTypeSeqToMetricIndex2<
                         typename Index2::type_seq_dimensions>::type>,
-        ddc::detail::TypeSeq<Index1, Index2>>;
+        ddc::detail::TypeSeq<uncharacterize<Index1>, uncharacterize<Index2>>>;
 
 template <TensorNatIndex Index1, TensorNatIndex Index2, class Dom>
 relabelize_metric_in_domain_t<Dom, Index1, Index2> relabelize_metric_in_domain(Dom metric_dom)
@@ -69,7 +69,7 @@ relabelize_metric_in_domain_t<Dom, Index1, Index2> relabelize_metric_in_domain(D
                             typename Index1::type_seq_dimensions>::type,
                     typename detail::ConvertTypeSeqToMetricIndex2<
                             typename Index2::type_seq_dimensions>::type>,
-            ddc::detail::TypeSeq<Index1, Index2>>(metric_dom);
+            ddc::detail::TypeSeq<uncharacterize<Index1>, uncharacterize<Index2>>>(metric_dom);
 }
 
 template <misc::Specialization<Tensor> TensorType, TensorNatIndex Index1, TensorNatIndex Index2>
@@ -80,7 +80,7 @@ using relabelize_metric_t = relabelize_indices_of_t<
                         typename Index1::type_seq_dimensions>::type,
                 typename detail::ConvertTypeSeqToMetricIndex2<
                         typename Index2::type_seq_dimensions>::type>,
-        ddc::detail::TypeSeq<Index1, Index2>>;
+        ddc::detail::TypeSeq<uncharacterize<Index1>, uncharacterize<Index2>>>;
 
 template <TensorNatIndex Index1, TensorNatIndex Index2, misc::Specialization<Tensor> TensorType>
 relabelize_metric_t<TensorType, Index1, Index2> relabelize_metric(TensorType tensor)
@@ -91,7 +91,7 @@ relabelize_metric_t<TensorType, Index1, Index2> relabelize_metric(TensorType ten
                             typename Index1::type_seq_dimensions>::type,
                     typename detail::ConvertTypeSeqToMetricIndex2<
                             typename Index2::type_seq_dimensions>::type>,
-            ddc::detail::TypeSeq<Index1, Index2>>(tensor);
+            ddc::detail::TypeSeq<uncharacterize<Index1>, uncharacterize<Index2>>>(tensor);
 }
 
 // Compute domain for a tensor product of metrics (ie. g_mu_muprime*g_nu_nuprime*...)

--- a/tests/tensor/tensor_field.cpp
+++ b/tests/tensor/tensor_field.cpp
@@ -65,8 +65,9 @@ TEST(TensorField, MetricLike)
 using ILow = sil::tensor::TensorCovariantNaturalIndex<I>;
 using JLow = sil::tensor::TensorCovariantNaturalIndex<J>;
 
-using MetricIndex = sil::tensor::
-        TensorSymmetricIndex<sil::tensor::MetricIndex1<X, Y>, sil::tensor::MetricIndex2<X, Y>>;
+using MetricIndex = sil::tensor::TensorSymmetricIndex<
+        sil::tensor::TensorCovariantNaturalIndex<sil::tensor::MetricIndex1<X, Y>>,
+        sil::tensor::TensorCovariantNaturalIndex<sil::tensor::MetricIndex2<X, Y>>>;
 
 TEST(TensorField, Metric)
 {


### PR DESCRIPTION
- Character in metric indexing (only covariant supported)
- Improve and simplify `RelabelizeIndex`
- Simplify `coboundary` implementation