### PR TITLE
Inverse metric

### DIFF
--- a/.devnote
+++ b/.devnote
@@ -15,6 +15,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
 - Optional compilation of embed-based modules
 - enforced_deep_copy (avoid call to Kokkos::deep_copy)
 - Rename TensorCovariantTensorIndex -> Covariant
+- Relabelizion in different file ?
 
 ----- CMAKE BASIC COMMAND -----
 

--- a/include/similie/tensor/character.hpp
+++ b/include/similie/tensor/character.hpp
@@ -65,10 +65,10 @@ struct Lower<TensorContravariantNaturalIndex<NaturalIndex>>
     using type = TensorCovariantNaturalIndex<NaturalIndex>;
 };
 
-template <TensorNatIndex... NaturalIndex>
-struct Lower<ddc::detail::TypeSeq<NaturalIndex...>>
+template <template <TensorIndex...> class T, TensorIndex... Index>
+struct Lower<T<Index...>>
 {
-    using type = ddc::detail::TypeSeq<typename Lower<NaturalIndex>::type...>;
+    using type = T<typename Lower<Index>::type...>;
 };
 
 } // namespace detail
@@ -93,10 +93,10 @@ struct Upper<TensorContravariantNaturalIndex<NaturalIndex>>
     using type = TensorContravariantNaturalIndex<NaturalIndex>;
 };
 
-template <TensorNatIndex... NaturalIndex>
-struct Upper<ddc::detail::TypeSeq<NaturalIndex...>>
+template <template <TensorIndex...> class T, TensorIndex... Index>
+struct Upper<T<Index...>>
 {
-    using type = ddc::detail::TypeSeq<typename Upper<NaturalIndex>::type...>;
+    using type = T<typename Upper<Index>::type...>;
 };
 
 } // namespace detail
@@ -121,10 +121,10 @@ struct Uncharacterize<TensorContravariantNaturalIndex<NaturalIndex>>
     using type = NaturalIndex;
 };
 
-template <class... Index>
-struct Uncharacterize<ddc::detail::TypeSeq<Index...>>
+template <template <TensorIndex...> class T, TensorIndex... Index>
+struct Uncharacterize<T<Index...>>
 {
-    using type = ddc::detail::TypeSeq<typename Uncharacterize<Index>::type...>;
+    using type = T<typename Uncharacterize<Index>::type...>;
 };
 
 template <class Index>

--- a/include/similie/tensor/character.hpp
+++ b/include/similie/tensor/character.hpp
@@ -107,6 +107,34 @@ using upper = detail::Upper<T>::type;
 namespace detail {
 
 template <class Index>
+struct SwapCharacter;
+
+template <TensorNatIndex NaturalIndex>
+struct SwapCharacter<TensorCovariantNaturalIndex<NaturalIndex>>
+{
+    using type = TensorContravariantNaturalIndex<NaturalIndex>;
+};
+
+template <TensorNatIndex NaturalIndex>
+struct SwapCharacter<TensorContravariantNaturalIndex<NaturalIndex>>
+{
+    using type = TensorCovariantNaturalIndex<NaturalIndex>;
+};
+
+template <template <TensorIndex...> class T, TensorIndex... Index>
+struct SwapCharacter<T<Index...>>
+{
+    using type = T<typename SwapCharacter<Index>::type...>;
+};
+
+} // namespace detail
+
+template <class T>
+using swap_character = detail::SwapCharacter<T>::type;
+
+namespace detail {
+
+template <class Index>
 struct Uncharacterize;
 
 template <class NaturalIndex>
@@ -141,6 +169,7 @@ struct Uncharacterize
 
 template <class Index>
 using uncharacterize = detail::Uncharacterize<Index>::type;
+
 
 // uncharacterize a tensor
 template <misc::Specialization<Tensor> TensorType>

--- a/include/similie/tensor/metric.hpp
+++ b/include/similie/tensor/metric.hpp
@@ -410,43 +410,6 @@ invert_metric_t<MetricType> fill_inverse_metric(
                 });
     }
 
-    /*
-    ddc::Chunk inv_metric_alloc(
-            relabelize_indices_in<
-                    typename MetricType::accessor_t::natural_domain_t,
-                    upper<typename MetricType::accessor_t::natural_domain_t>>(
-                    tensor.domain()),
-            ddc::HostAllocator<double>());
-    relabelize_indices_of_t<
-            MetricType,
-            typename MetricType::accessor_t::natural_domain_t,
-                    upper<typename MetricType::accessor_t::natural_domain_t>>
-            inv_metric(inv_metric_alloc);
-    */
-    /*
-    relabelize_indices_of_t<
-            TensorType,
-            upper<detail::non_primes<typename MetricType::accessor_t::natural_domain_t>>,
-            detail::non_primes<typename MetricType::accessor_t::natural_domain_t>>
-            result(result_alloc);
-    ddc::for_each( // TODO use parallel_for_each, there is a weird lock when doing so
-            tensor.non_indices_domain(),
-            [&](auto elem) {
-                tensor_prod(
-                        result[elem],
-                        metric_prod[elem],
-                        relabelize_indices_of<
-                                upper<detail::non_primes<
-                                        typename MetricType::accessor_t::natural_domain_t>>,
-                                primes<upper<detail::non_primes<
-                                        typename MetricType::accessor_t::natural_domain_t>>>>(
-                                tensor)[elem]);
-            });
-    Kokkos::deep_copy(
-            tensor.allocation_kokkos_view(),
-            result.allocation_kokkos_view()); // We rely on Kokkos::deep_copy in place of ddc::parallel_deepcopy to avoid type verification of the type dimensions
-    */
-
     return inv_metric;
 }
 

--- a/include/similie/tensor/metric.hpp
+++ b/include/similie/tensor/metric.hpp
@@ -276,13 +276,14 @@ auto inplace_apply_metric(TensorType tensor, MetricType metric_prod)
 {
     ddc::Chunk result_alloc(
             relabelize_indices_in<
-                    upper<detail::non_primes<typename MetricType::accessor_t::natural_domain_t>>,
+                    swap_character<
+                            detail::non_primes<typename MetricType::accessor_t::natural_domain_t>>,
                     detail::non_primes<typename MetricType::accessor_t::natural_domain_t>>(
                     tensor.domain()),
             ddc::HostAllocator<double>());
     relabelize_indices_of_t<
             TensorType,
-            upper<detail::non_primes<typename MetricType::accessor_t::natural_domain_t>>,
+            swap_character<detail::non_primes<typename MetricType::accessor_t::natural_domain_t>>,
             detail::non_primes<typename MetricType::accessor_t::natural_domain_t>>
             result(result_alloc);
     ddc::for_each( // TODO use parallel_for_each, there is a weird lock when doing so
@@ -292,9 +293,9 @@ auto inplace_apply_metric(TensorType tensor, MetricType metric_prod)
                         result[elem],
                         metric_prod[elem],
                         relabelize_indices_of<
-                                upper<detail::non_primes<
+                                swap_character<detail::non_primes<
                                         typename MetricType::accessor_t::natural_domain_t>>,
-                                primes<upper<detail::non_primes<
+                                primes<swap_character<detail::non_primes<
                                         typename MetricType::accessor_t::natural_domain_t>>>>(
                                 tensor)[elem]);
             });
@@ -303,7 +304,7 @@ auto inplace_apply_metric(TensorType tensor, MetricType metric_prod)
             result.allocation_kokkos_view()); // We rely on Kokkos::deep_copy in place of ddc::parallel_deepcopy to avoid type verification of the type dimensions
 
     return relabelize_indices_of<
-            upper<detail::non_primes<typename MetricType::accessor_t::natural_domain_t>>,
+            swap_character<detail::non_primes<typename MetricType::accessor_t::natural_domain_t>>,
             detail::non_primes<typename MetricType::accessor_t::natural_domain_t>>(tensor);
 }
 
@@ -314,7 +315,7 @@ template <
         misc::Specialization<Tensor> TensorType>
 relabelize_indices_of_t<
         TensorType,
-        upper<ddc::detail::TypeSeq<Index1...>>,
+        swap_character<ddc::detail::TypeSeq<Index1...>>,
         ddc::detail::TypeSeq<Index1...>>
 inplace_apply_metric(TensorType tensor, MetricType metric)
 {
@@ -357,9 +358,9 @@ template <misc::Specialization<Tensor> MetricType>
 using invert_metric_t = relabelize_indices_of_t<
         MetricType,
         ddc::to_type_seq_t<typename MetricType::accessor_t::natural_domain_t>,
-        upper<ddc::to_type_seq_t<typename MetricType::accessor_t::natural_domain_t>>>;
+        swap_character<ddc::to_type_seq_t<typename MetricType::accessor_t::natural_domain_t>>>;
 
-// Apply metrics inplace (like g_mu_muprime*T^muprime^nu)
+// Compute invert metric (g_mu_nu for gmunu or gmunu for g_mu_nu)
 template <TensorIndex MetricIndex, misc::Specialization<Tensor> MetricType>
 invert_metric_t<MetricType> fill_inverse_metric(
         invert_metric_t<MetricType> inv_metric,
@@ -376,7 +377,7 @@ invert_metric_t<MetricType> fill_inverse_metric(
                     inv_metric(elem)
                             = 1.
                               / metric(relabelize_indices_in<
-                                       upper<ddc::to_type_seq_t<
+                                       swap_character<ddc::to_type_seq_t<
                                                typename MetricType::accessor_t::natural_domain_t>>,
                                        ddc::to_type_seq_t<
                                                typename MetricType::accessor_t::natural_domain_t>>(

--- a/include/similie/tensor/metric.hpp
+++ b/include/similie/tensor/metric.hpp
@@ -346,6 +346,58 @@ inplace_apply_metric(TensorType tensor, MetricType metric)
     return inplace_apply_metric(tensor, metric_prod);
 }
 
+template <misc::Specialization<Tensor> MetricType>
+using invert_metric_t = relabelize_indices_of_t<
+        MetricType,
+        ddc::to_type_seq_t<typename MetricType::accessor_t::natural_domain_t>,
+        upper<ddc::to_type_seq_t<typename MetricType::accessor_t::natural_domain_t>>>;
+
+// Apply metrics inplace (like g_mu_muprime*T^muprime^nu)
+template <misc::Specialization<Tensor> MetricType>
+invert_metric_t<MetricType> fill_inverse_metric(
+        invert_metric_t<MetricType> inv_metric,
+        MetricType metric)
+{
+    /*
+    ddc::Chunk inv_metric_alloc(
+            relabelize_indices_in_domain<
+                    typename MetricType::accessor_t::natural_domain_t,
+                    upper<typename MetricType::accessor_t::natural_domain_t>>(
+                    tensor.domain()),
+            ddc::HostAllocator<double>());
+    relabelize_indices_of_t<
+            MetricType,
+            typename MetricType::accessor_t::natural_domain_t,
+                    upper<typename MetricType::accessor_t::natural_domain_t>>
+            inv_metric(inv_metric_alloc);
+    */
+    /*
+    relabelize_indices_of_t<
+            TensorType,
+            upper<detail::non_primes<typename MetricType::accessor_t::natural_domain_t>>,
+            detail::non_primes<typename MetricType::accessor_t::natural_domain_t>>
+            result(result_alloc);
+    ddc::for_each( // TODO use parallel_for_each, there is a weird lock when doing so
+            tensor.non_indices_domain(),
+            [&](auto elem) {
+                tensor_prod(
+                        result[elem],
+                        metric_prod[elem],
+                        relabelize_indices_of<
+                                upper<detail::non_primes<
+                                        typename MetricType::accessor_t::natural_domain_t>>,
+                                primes<upper<detail::non_primes<
+                                        typename MetricType::accessor_t::natural_domain_t>>>>(
+                                tensor)[elem]);
+            });
+    Kokkos::deep_copy(
+            tensor.allocation_kokkos_view(),
+            result.allocation_kokkos_view()); // We rely on Kokkos::deep_copy in place of ddc::parallel_deepcopy to avoid type verification of the type dimensions
+    */
+
+    return inv_metric;
+}
+
 } // namespace tensor
 
 } // namespace sil

--- a/include/similie/tensor/metric.hpp
+++ b/include/similie/tensor/metric.hpp
@@ -364,16 +364,14 @@ invert_metric_t<MetricType> fill_inverse_metric(
         invert_metric_t<MetricType> inv_metric,
         MetricType metric)
 {
-    if constexpr (misc::Specialization<MetricType, TensorIdentityIndex>) {
-    } else if (
-            misc::Specialization<MetricType, TensorLorentzianSignIndex>
-            || misc::Specialization<MetricType, TensorDiagonalIndex>) {
+    if constexpr (
+            misc::Specialization<MetricType, TensorIdentityIndex>
+            || misc::Specialization<MetricType, TensorLorentzianSignIndex>) {
+    } else if (misc::Specialization<MetricType, TensorDiagonalIndex>) {
         ddc::parallel_for_each(
                 Kokkos::DefaultHostExecutionSpace(),
                 inv_metric.mem_domain(),
-                [&](auto elem) {
-                    // inv_metric(elem) = 1./metric(elem);
-                });
+                [&](auto elem) { /* inv_metric(elem) = 1. / metric(elem); */ });
     } else if (misc::Specialization<MetricType, TensorSymmetricIndex>) {
         /*
         ddc::parallel_for_each(

--- a/include/similie/tensor/metric.hpp
+++ b/include/similie/tensor/metric.hpp
@@ -57,7 +57,7 @@ template <
         misc::Specialization<ddc::DiscreteDomain> Dom,
         TensorNatIndex Index1,
         TensorNatIndex Index2>
-using relabelize_metric_in_domain_t = relabelize_indices_in_domain_t<
+using relabelize_metric_in_domain_t = relabelize_indices_in_t<
         Dom,
         ddc::detail::TypeSeq<
                 typename detail::ConvertTypeSeqToMetricIndex1<
@@ -69,7 +69,7 @@ using relabelize_metric_in_domain_t = relabelize_indices_in_domain_t<
 template <TensorNatIndex Index1, TensorNatIndex Index2, class Dom>
 relabelize_metric_in_domain_t<Dom, Index1, Index2> relabelize_metric_in_domain(Dom metric_dom)
 {
-    return relabelize_indices_in_domain<
+    return relabelize_indices_in<
             ddc::detail::TypeSeq<
                     typename detail::ConvertTypeSeqToMetricIndex1<
                             typename Index1::type_seq_dimensions>::type,
@@ -274,7 +274,7 @@ template <misc::Specialization<Tensor> MetricType, misc::Specialization<Tensor> 
 auto inplace_apply_metric(TensorType tensor, MetricType metric_prod)
 {
     ddc::Chunk result_alloc(
-            relabelize_indices_in_domain<
+            relabelize_indices_in<
                     upper<detail::non_primes<typename MetricType::accessor_t::natural_domain_t>>,
                     detail::non_primes<typename MetricType::accessor_t::natural_domain_t>>(
                     tensor.domain()),
@@ -390,7 +390,7 @@ invert_metric_t<MetricType> fill_inverse_metric(
 
     /*
     ddc::Chunk inv_metric_alloc(
-            relabelize_indices_in_domain<
+            relabelize_indices_in<
                     typename MetricType::accessor_t::natural_domain_t,
                     upper<typename MetricType::accessor_t::natural_domain_t>>(
                     tensor.domain()),

--- a/include/similie/tensor/metric.hpp
+++ b/include/similie/tensor/metric.hpp
@@ -371,7 +371,16 @@ invert_metric_t<MetricType> fill_inverse_metric(
         ddc::parallel_for_each(
                 Kokkos::DefaultHostExecutionSpace(),
                 inv_metric.mem_domain(),
-                [&](auto elem) { /* inv_metric(elem) = 1. / metric(elem); */ });
+                [&](auto elem) {
+                    inv_metric(elem)
+                            = 1.
+                              / metric(relabelize_indices_in<
+                                       upper<ddc::to_type_seq_t<
+                                               typename MetricType::accessor_t::natural_domain_t>>,
+                                       ddc::to_type_seq_t<
+                                               typename MetricType::accessor_t::natural_domain_t>>(
+                                      elem));
+                });
     } else if (misc::Specialization<MetricType, TensorSymmetricIndex>) {
         /*
         ddc::parallel_for_each(

--- a/include/similie/tensor/tensor_impl.hpp
+++ b/include/similie/tensor/tensor_impl.hpp
@@ -845,7 +845,7 @@ using relabelize_indices_in_t =
 namespace detail {
 
 template <class OldIndices, class NewIndices, std::size_t I = 0>
-struct RelabelizeIndicesInElement
+struct RelabelizeIndicesIn
 {
     template <class... DDim>
     static auto run(ddc::DiscreteElement<DDim...> elem)
@@ -859,22 +859,7 @@ struct RelabelizeIndicesInElement
             return elem;
         }
     }
-};
 
-} // namespace detail
-
-template <class OldIndices, class NewIndices, misc::Specialization<ddc::DiscreteElement> Elem>
-relabelize_indices_in_t<Elem, OldIndices, NewIndices> relabelize_indices_in_element(Elem elem)
-{
-    static_assert(ddc::type_seq_size_v<OldIndices> == ddc::type_seq_size_v<NewIndices>);
-    return detail::RelabelizeIndicesInElement<OldIndices, NewIndices>::run(elem);
-}
-
-namespace detail {
-
-template <class OldIndices, class NewIndices, std::size_t I = 0>
-struct RelabelizeIndicesInVector
-{
     template <class... DDim>
     static auto run(ddc::DiscreteVector<DDim...> vect)
     {
@@ -888,21 +873,7 @@ struct RelabelizeIndicesInVector
             return vect;
         }
     }
-};
 
-} // namespace detail
-
-template <class OldIndices, class NewIndices, misc::Specialization<ddc::DiscreteVector> Vect>
-relabelize_indices_in_t<Vect, OldIndices, NewIndices> relabelize_indices_in_vector(Vect vect)
-{
-    static_assert(ddc::type_seq_size_v<OldIndices> == ddc::type_seq_size_v<NewIndices>);
-    return detail::RelabelizeIndicesInVector<OldIndices, NewIndices>::run(vect);
-}
-namespace detail {
-
-template <class OldIndices, class NewIndices, std::size_t I = 0>
-struct RelabelizeIndicesIn
-{
     template <class... DDim>
     static auto run(ddc::DiscreteDomain<DDim...> dom)
     {
@@ -912,11 +883,11 @@ struct RelabelizeIndicesIn
                             ddc::DiscreteDomain<DDim...>,
                             ddc::type_seq_element_t<I, OldIndices>,
                             ddc::type_seq_element_t<I, NewIndices>>(
-                            relabelize_indices_in_element< // TODO relabelize_index_in
+                            relabelize_indices_in<
                                     ddc::detail::TypeSeq<ddc::type_seq_element_t<I, OldIndices>>,
                                     ddc::detail::TypeSeq<ddc::type_seq_element_t<I, NewIndices>>>(
                                     dom.front()),
-                            relabelize_indices_in_vector<
+                            relabelize_indices_in<
                                     ddc::detail::TypeSeq<ddc::type_seq_element_t<I, OldIndices>>,
                                     ddc::detail::TypeSeq<ddc::type_seq_element_t<I, NewIndices>>>(
                                     dom.extents())));
@@ -928,11 +899,11 @@ struct RelabelizeIndicesIn
 
 } // namespace detail
 
-template <class OldIndices, class NewIndices, misc::Specialization<ddc::DiscreteDomain> Dom>
-relabelize_indices_in_t<Dom, OldIndices, NewIndices> relabelize_indices_in(Dom dom)
+template <class OldIndices, class NewIndices, class T>
+relabelize_indices_in_t<T, OldIndices, NewIndices> relabelize_indices_in(T t)
 {
     static_assert(ddc::type_seq_size_v<OldIndices> == ddc::type_seq_size_v<NewIndices>);
-    return detail::RelabelizeIndicesIn<OldIndices, NewIndices>::run(dom);
+    return detail::RelabelizeIndicesIn<OldIndices, NewIndices>::run(t);
 }
 
 namespace detail {

--- a/include/similie/tensor/tensor_impl.hpp
+++ b/include/similie/tensor/tensor_impl.hpp
@@ -888,11 +888,9 @@ struct RelabelizeIndicesIn
     {
         if constexpr (I != ddc::type_seq_size_v<OldIndices>) {
             return RelabelizeIndicesIn<OldIndices, NewIndices, I + 1>::run(
-                    ddc::DiscreteElement<typename detail::RelabelizeIndex<
-                            DDim,
+                    relabelize_index_in<
                             ddc::type_seq_element_t<I, OldIndices>,
-                            ddc::type_seq_element_t<I, NewIndices>>::type...>(
-                            elem.template uid<DDim>()...));
+                            ddc::type_seq_element_t<I, NewIndices>>(elem));
         } else {
             return elem;
         }
@@ -903,11 +901,9 @@ struct RelabelizeIndicesIn
     {
         if constexpr (I != ddc::type_seq_size_v<OldIndices>) {
             return RelabelizeIndicesIn<OldIndices, NewIndices, I + 1>::run(
-                    ddc::DiscreteVector<typename detail::RelabelizeIndex<
-                            DDim,
+                    relabelize_index_in<
                             ddc::type_seq_element_t<I, OldIndices>,
-                            ddc::type_seq_element_t<I, NewIndices>>::type...>(
-                            static_cast<std::size_t>(vect.template get<DDim>())...));
+                            ddc::type_seq_element_t<I, NewIndices>>(vect));
         } else {
             return vect;
         }
@@ -918,18 +914,9 @@ struct RelabelizeIndicesIn
     {
         if constexpr (I != ddc::type_seq_size_v<OldIndices>) {
             return RelabelizeIndicesIn<OldIndices, NewIndices, I + 1>::run(
-                    relabelize_index_in_t<
-                            ddc::DiscreteDomain<DDim...>,
+                    relabelize_index_in<
                             ddc::type_seq_element_t<I, OldIndices>,
-                            ddc::type_seq_element_t<I, NewIndices>>(
-                            relabelize_indices_in<
-                                    ddc::detail::TypeSeq<ddc::type_seq_element_t<I, OldIndices>>,
-                                    ddc::detail::TypeSeq<ddc::type_seq_element_t<I, NewIndices>>>(
-                                    dom.front()),
-                            relabelize_indices_in<
-                                    ddc::detail::TypeSeq<ddc::type_seq_element_t<I, OldIndices>>,
-                                    ddc::detail::TypeSeq<ddc::type_seq_element_t<I, NewIndices>>>(
-                                    dom.extents())));
+                            ddc::type_seq_element_t<I, NewIndices>>(dom));
         } else {
             return dom;
         }

--- a/include/similie/tensor/tensor_impl.hpp
+++ b/include/similie/tensor/tensor_impl.hpp
@@ -851,10 +851,12 @@ struct RelabelizeIndicesIn
     static auto run(ddc::DiscreteElement<DDim...> elem)
     {
         if constexpr (I != ddc::type_seq_size_v<OldIndices>) {
-            return ddc::DiscreteElement<typename detail::RelabelizeIndex<
-                    DDim,
-                    ddc::type_seq_element_t<I, OldIndices>,
-                    ddc::type_seq_element_t<I, NewIndices>>::type...>(elem.template uid<DDim>()...);
+            return RelabelizeIndicesIn<OldIndices, NewIndices, I + 1>::run(
+                    ddc::DiscreteElement<typename detail::RelabelizeIndex<
+                            DDim,
+                            ddc::type_seq_element_t<I, OldIndices>,
+                            ddc::type_seq_element_t<I, NewIndices>>::type...>(
+                            elem.template uid<DDim>()...));
         } else {
             return elem;
         }
@@ -864,11 +866,12 @@ struct RelabelizeIndicesIn
     static auto run(ddc::DiscreteVector<DDim...> vect)
     {
         if constexpr (I != ddc::type_seq_size_v<OldIndices>) {
-            return ddc::DiscreteVector<typename detail::RelabelizeIndex<
-                    DDim,
-                    ddc::type_seq_element_t<I, OldIndices>,
-                    ddc::type_seq_element_t<I, NewIndices>>::type...>(
-                    static_cast<std::size_t>(vect.template get<DDim>())...);
+            return RelabelizeIndicesIn<OldIndices, NewIndices, I + 1>::run(
+                    ddc::DiscreteVector<typename detail::RelabelizeIndex<
+                            DDim,
+                            ddc::type_seq_element_t<I, OldIndices>,
+                            ddc::type_seq_element_t<I, NewIndices>>::type...>(
+                            static_cast<std::size_t>(vect.template get<DDim>())...));
         } else {
             return vect;
         }

--- a/tests/tensor/CMakeLists.txt
+++ b/tests/tensor/CMakeLists.txt
@@ -25,13 +25,13 @@ target_link_libraries(unit_tests_tensor_prod
 
 gtest_discover_tests(unit_tests_tensor_prod DISCOVERY_MODE PRE_TEST)
 
-add_executable(unit_tests_tensor_field tensor_field.cpp ../main.cpp)
+add_executable(unit_tests_metric metric.cpp ../main.cpp)
 
-target_link_libraries(unit_tests_tensor_field
+target_link_libraries(unit_tests_metric
     PUBLIC
         GTest::gtest
         DDC::DDC
         sil::tensor
 )
 
-gtest_discover_tests(unit_tests_tensor_field DISCOVERY_MODE PRE_TEST)
+gtest_discover_tests(unit_tests_metric DISCOVERY_MODE PRE_TEST)

--- a/tests/tensor/metric.cpp
+++ b/tests/tensor/metric.cpp
@@ -225,6 +225,11 @@ TEST(Metric, Inverse)
             Kokkos::layout_right,
             Kokkos::DefaultHostExecutionSpace::memory_space>
             metric(metric_alloc);
+    ddc::for_each(mesh_xy, [&](ddc::DiscreteElement<DDimX, DDimY> elem) {
+        metric(elem, metric.accessor().access_element<X, X>()) = 1.;
+        metric(elem, metric.accessor().access_element<X, Y>()) = 2.;
+        metric(elem, metric.accessor().access_element<Y, Y>()) = 3.;
+    });
 
     sil::tensor::TensorAccessor<InvMetricIndex> inv_metric_accessor;
     ddc::DiscreteDomain<DDimX, DDimY, InvMetricIndex>
@@ -237,5 +242,6 @@ TEST(Metric, Inverse)
             Kokkos::DefaultHostExecutionSpace::memory_space>
             inv_metric(inv_metric_alloc);
 
-    sil::tensor::fill_inverse_metric(inv_metric, metric);
+    sil::tensor::fill_inverse_metric<MetricIndex>(inv_metric, metric);
+    std::cout << inv_metric;
 }

--- a/tests/tensor/metric.cpp
+++ b/tests/tensor/metric.cpp
@@ -286,23 +286,11 @@ TEST(Metric, Inverse)
                                 metric[elem]));
             });
     ddc::for_each(mesh_xy, [&](ddc::DiscreteElement<DDimX, DDimY> elem) {
-        EXPECT_NEAR(
-                identity.get(elem, identity.accessor().access_element<X, X>()),
-                1., 1e-14);
-        EXPECT_NEAR(
-                identity.get(elem, identity.accessor().access_element<X, Y>()),
-                0., 1e-14);
-        EXPECT_NEAR(
-                identity.get(elem, identity.accessor().access_element<X, Z>()),
-                0., 1e-14);
-        EXPECT_NEAR(
-                identity.get(elem, identity.accessor().access_element<Y, Y>()),
-                1., 1e-14);
-        EXPECT_NEAR(
-                identity.get(elem, identity.accessor().access_element<Y, Z>()),
-                0., 1e-14);
-        EXPECT_NEAR(
-                identity.get(elem, identity.accessor().access_element<Z, Z>()),
-                1., 1e-14);
+        EXPECT_NEAR(identity.get(elem, identity.accessor().access_element<X, X>()), 1., 1e-14);
+        EXPECT_NEAR(identity.get(elem, identity.accessor().access_element<X, Y>()), 0., 1e-14);
+        EXPECT_NEAR(identity.get(elem, identity.accessor().access_element<X, Z>()), 0., 1e-14);
+        EXPECT_NEAR(identity.get(elem, identity.accessor().access_element<Y, Y>()), 1., 1e-14);
+        EXPECT_NEAR(identity.get(elem, identity.accessor().access_element<Y, Z>()), 0., 1e-14);
+        EXPECT_NEAR(identity.get(elem, identity.accessor().access_element<Z, Z>()), 1., 1e-14);
     });
 }


### PR DESCRIPTION
- Improve `relabelize_index_in`-like functions (previously `relabelize_index_in_domain`)
- Improve character support and add `swap_character`
- Add `fill_inverse_metric` which relies on `KokkosBatched::InverseLU` (kokkos-kernels)
- Associated test.