### PR TITLE
Simplify tensor indexes

### DIFF
--- a/.devnote
+++ b/.devnote
@@ -21,8 +21,6 @@ SPDX-License-Identifier: GPL-3.0-or-later
 - Remove metric_prod_t (and every helper producing a tensor)
 - is_same_character_v and use it in tensor product
 - find a way to use CTAD when constructing a Tensor and DiscreteDomain
-- static constexpr attribute in TensorIndex classes to know if it returns mem_lin_comb of just mem_id
-- Precise "natural_ids" as attributes of mem_lin_comb
 
 ----- CMAKE BASIC COMMAND -----
 

--- a/include/similie/tensor/antisymmetric_tensor.hpp
+++ b/include/similie/tensor/antisymmetric_tensor.hpp
@@ -18,6 +18,7 @@ template <class... TensorIndex>
 struct TensorAntisymmetricIndex
 {
     static constexpr bool is_tensor_index = true;
+    static constexpr bool is_explicitely_stored_tensor = true;
 
     using subindices_domain_t = ddc::DiscreteDomain<TensorIndex...>;
 
@@ -67,38 +68,31 @@ struct TensorAntisymmetricIndex
         }
     }
 
-    static constexpr std::pair<std::vector<double>, std::vector<std::size_t>> mem_lin_comb(
-            std::array<std::size_t, rank()> const ids)
+    static constexpr std::size_t mem_id(std::array<std::size_t, rank()> const natural_ids)
     {
-        std::array<std::size_t, rank()> sorted_ids(ids);
+        std::array<std::size_t, rank()> sorted_ids(natural_ids);
         std::sort(sorted_ids.begin(), sorted_ids.end());
-        return std::pair<std::vector<double>, std::vector<std::size_t>>(
-                std::vector<double> {1.},
-                std::vector<std::size_t> {static_cast<std::size_t>(
-                        mem_size()
-                        - (0 + ...
-                           + (sorted_ids[ddc::type_seq_rank_v<
-                                      TensorIndex,
-                                      ddc::detail::TypeSeq<TensorIndex...>>]
-                                              == TensorIndex::mem_size() - rank()
-                                                         + ddc::type_seq_rank_v<
-                                                                 TensorIndex,
-                                                                 ddc::detail::TypeSeq<
-                                                                         TensorIndex...>>
-                                      ? 0
-                                      : misc::binomial_coefficient(
-                                                TensorIndex::mem_size()
-                                                        - sorted_ids[ddc::type_seq_rank_v<
-                                                                TensorIndex,
-                                                                ddc::detail::TypeSeq<
-                                                                        TensorIndex...>>]
-                                                        - 1,
-                                                rank()
-                                                        - ddc::type_seq_rank_v<
-                                                                TensorIndex,
-                                                                ddc::detail::TypeSeq<
-                                                                        TensorIndex...>>)))
-                        - 1)});
+        return mem_size()
+               - (0 + ...
+                  + (sorted_ids[ddc::type_seq_rank_v<
+                             TensorIndex,
+                             ddc::detail::TypeSeq<TensorIndex...>>]
+                                     == TensorIndex::mem_size() - rank()
+                                                + ddc::type_seq_rank_v<
+                                                        TensorIndex,
+                                                        ddc::detail::TypeSeq<TensorIndex...>>
+                             ? 0
+                             : misc::binomial_coefficient(
+                                       TensorIndex::mem_size()
+                                               - sorted_ids[ddc::type_seq_rank_v<
+                                                       TensorIndex,
+                                                       ddc::detail::TypeSeq<TensorIndex...>>]
+                                               - 1,
+                                       rank()
+                                               - ddc::type_seq_rank_v<
+                                                       TensorIndex,
+                                                       ddc::detail::TypeSeq<TensorIndex...>>)))
+               - 1;
     }
 
 private:
@@ -113,40 +107,32 @@ private:
     }
 
 public:
-    static constexpr std::size_t access_id(std::array<std::size_t, rank()> const ids)
+    static constexpr std::size_t access_id(std::array<std::size_t, rank()> const natural_ids)
     {
         if constexpr (rank() <= 1) {
-            return std::get<1>(mem_lin_comb(ids))[0];
+            return mem_id(natural_ids);
         } else {
-            if (std::all_of(ids.begin(), ids.end(), [&](const std::size_t id) {
-                    return id == *ids.begin();
+            if (std::all_of(natural_ids.begin(), natural_ids.end(), [&](const std::size_t id) {
+                    return id == *natural_ids.begin();
                 })) {
                 return 0;
-            } else if (!permutation_parity(ids)) {
-                return 1 + std::get<1>(mem_lin_comb(ids))[0];
+            } else if (!permutation_parity(natural_ids)) {
+                return 1 + mem_id(natural_ids);
             } else {
-                return access_size() + std::get<1>(mem_lin_comb(ids))[0];
+                return access_size() + mem_id(natural_ids);
             }
         }
     }
 
-    static constexpr std::pair<std::vector<double>, std::vector<std::size_t>>
-    access_id_to_mem_lin_comb(std::size_t access_id)
+    static constexpr std::size_t access_id_to_mem_id(std::size_t access_id)
     {
         if constexpr (rank() <= 1) {
-            return std::pair<std::vector<double>, std::vector<std::size_t>>(
-                    std::vector<double> {1.},
-                    std::vector<std::size_t> {access_id});
+            return access_id;
         } else {
             if (access_id != 0) {
-                return std::pair<std::vector<double>, std::vector<std::size_t>>(
-                        std::vector<double> {1.},
-                        std::vector<std::size_t> {(access_id - 1) % mem_size()});
+                return (access_id - 1) % mem_size();
             } else {
-                return std::pair<
-                        std::vector<double>,
-                        std::vector<
-                                std::size_t>>(std::vector<double> {}, std::vector<std::size_t> {});
+                return std::numeric_limits<std::size_t>::infinity();
             }
         }
     }

--- a/include/similie/tensor/antisymmetric_tensor.hpp
+++ b/include/similie/tensor/antisymmetric_tensor.hpp
@@ -132,7 +132,7 @@ public:
             if (access_id != 0) {
                 return (access_id - 1) % mem_size();
             } else {
-                return std::numeric_limits<std::size_t>::infinity();
+                return std::numeric_limits<std::size_t>::max();
             }
         }
     }

--- a/include/similie/tensor/diagonal_tensor.hpp
+++ b/include/similie/tensor/diagonal_tensor.hpp
@@ -18,6 +18,7 @@ template <class... TensorIndex>
 struct TensorDiagonalIndex
 {
     static constexpr bool is_tensor_index = true;
+    static constexpr bool is_explicitely_stored_tensor = true;
 
     using subindices_domain_t = ddc::DiscreteDomain<TensorIndex...>;
 
@@ -49,37 +50,31 @@ struct TensorDiagonalIndex
         return 1 + mem_size();
     }
 
-    static constexpr std::pair<std::vector<double>, std::vector<std::size_t>> mem_lin_comb(
-            std::array<std::size_t, sizeof...(TensorIndex)> const ids)
+    static constexpr std::size_t mem_id(
+            std::array<std::size_t, sizeof...(TensorIndex)> const natural_ids)
     {
-        assert(std::all_of(ids.begin(), ids.end(), [&](const std::size_t id) {
-            return id == *ids.begin();
+        assert(std::all_of(natural_ids.begin(), natural_ids.end(), [&](const std::size_t id) {
+            return id == *natural_ids.begin();
         }));
-        return std::pair<
-                std::vector<double>,
-                std::vector<
-                        std::size_t>>(std::vector<double> {1.}, std::vector<std::size_t> {ids[0]});
+        return natural_ids[0];
     }
 
     static constexpr std::size_t access_id(
-            std::array<std::size_t, sizeof...(TensorIndex)> const ids)
+            std::array<std::size_t, sizeof...(TensorIndex)> const natural_ids)
     {
-        if (!std::all_of(ids.begin(), ids.end(), [&](const std::size_t id) {
-                return id == *ids.begin();
+        if (!std::all_of(natural_ids.begin(), natural_ids.end(), [&](const std::size_t id) {
+                return id == *natural_ids.begin();
             })) {
             return 0;
         } else {
-            return 1 + std::get<1>(mem_lin_comb(ids))[0];
+            return 1 + mem_id(natural_ids);
         }
     }
 
-    static constexpr std::pair<std::vector<double>, std::vector<std::size_t>>
-    access_id_to_mem_lin_comb(std::size_t access_id)
+    static constexpr std::size_t access_id_to_mem_id(std::size_t access_id)
     {
-        assert(access_id != 0 && "There is no mem_lin_comb associated to access_id=0");
-        return std::pair<std::vector<double>, std::vector<std::size_t>>(
-                std::vector<double> {1.},
-                std::vector<std::size_t> {access_id - 1});
+        assert(access_id != 0 && "There is no mem_id associated to access_id=0");
+        return access_id - 1;
     }
 
     template <class Tensor, class Elem, class Id>

--- a/include/similie/tensor/full_tensor.hpp
+++ b/include/similie/tensor/full_tensor.hpp
@@ -18,6 +18,7 @@ template <class... TensorIndex>
 struct TensorFullIndex
 {
     static constexpr bool is_tensor_index = true;
+    static constexpr bool is_explicitely_stored_tensor = true;
 
     using subindices_domain_t = ddc::DiscreteDomain<TensorIndex...>;
 
@@ -49,28 +50,24 @@ struct TensorFullIndex
         return (TensorIndex::access_size() * ...);
     }
 
-    static constexpr std::pair<std::vector<double>, std::vector<std::size_t>> mem_lin_comb(
-            std::array<std::size_t, sizeof...(TensorIndex)> const ids)
+    static constexpr std::size_t mem_id(
+            std::array<std::size_t, sizeof...(TensorIndex)> const natural_ids)
     {
-        return std::pair<std::vector<double>, std::vector<std::size_t>>(
-                std::vector<double> {1.},
-                std::vector<std::size_t> {access_id(ids)});
+        return access_id(natural_ids);
     }
 
     static constexpr std::size_t access_id(
-            std::array<std::size_t, sizeof...(TensorIndex)> const ids)
+            std::array<std::size_t, sizeof...(TensorIndex)> const natural_ids)
     {
         return ((misc::detail::stride<TensorIndex, TensorIndex...>()
-                 * ids[ddc::type_seq_rank_v<TensorIndex, ddc::detail::TypeSeq<TensorIndex...>>])
+                 * natural_ids
+                         [ddc::type_seq_rank_v<TensorIndex, ddc::detail::TypeSeq<TensorIndex...>>])
                 + ...);
     }
 
-    static constexpr std::pair<std::vector<double>, std::vector<std::size_t>>
-    access_id_to_mem_lin_comb(std::size_t access_id)
+    static constexpr std::size_t access_id_to_mem_id(std::size_t access_id)
     {
-        return std::pair<std::vector<double>, std::vector<std::size_t>>(
-                std::vector<double> {1.},
-                std::vector<std::size_t> {access_id});
+        return access_id;
     }
 
     template <class Tensor, class Elem, class Id>

--- a/include/similie/tensor/identity_tensor.hpp
+++ b/include/similie/tensor/identity_tensor.hpp
@@ -16,6 +16,7 @@ template <class... TensorIndex>
 struct TensorIdentityIndex
 {
     static constexpr bool is_tensor_index = true;
+    static constexpr bool is_explicitely_stored_tensor = true;
 
     using subindices_domain_t = ddc::DiscreteDomain<TensorIndex...>;
 
@@ -47,19 +48,17 @@ struct TensorIdentityIndex
         return 2;
     }
 
-    static constexpr std::pair<std::vector<double>, std::vector<std::size_t>> mem_lin_comb(
-            std::array<std::size_t, sizeof...(TensorIndex)> const ids)
+    static constexpr std::size_t mem_id(
+            std::array<std::size_t, sizeof...(TensorIndex)> const natural_ids)
     {
-        return std::pair<
-                std::vector<double>,
-                std::vector<std::size_t>>(std::vector<double> {}, std::vector<std::size_t> {});
+        return std::numeric_limits<std::size_t>::infinity();
     }
 
     static constexpr std::size_t access_id(
-            std::array<std::size_t, sizeof...(TensorIndex)> const ids)
+            std::array<std::size_t, sizeof...(TensorIndex)> const natural_ids)
     {
-        if (!std::all_of(ids.begin(), ids.end(), [&](const std::size_t id) {
-                return id == *ids.begin();
+        if (!std::all_of(natural_ids.begin(), natural_ids.end(), [&](const std::size_t id) {
+                return id == *natural_ids.begin();
             })) {
             return 0;
         } else {
@@ -67,12 +66,9 @@ struct TensorIdentityIndex
         }
     }
 
-    static constexpr std::pair<std::vector<double>, std::vector<std::size_t>>
-    access_id_to_mem_lin_comb(std::size_t access_id)
+    static constexpr std::size_t access_id_to_mem_id(std::size_t access_id)
     {
-        return std::pair<
-                std::vector<double>,
-                std::vector<std::size_t>>(std::vector<double> {}, std::vector<std::size_t> {});
+        return std::numeric_limits<std::size_t>::infinity();
     }
 
     template <class Tensor, class Elem, class Id>

--- a/include/similie/tensor/identity_tensor.hpp
+++ b/include/similie/tensor/identity_tensor.hpp
@@ -51,7 +51,7 @@ struct TensorIdentityIndex
     static constexpr std::size_t mem_id(
             std::array<std::size_t, sizeof...(TensorIndex)> const natural_ids)
     {
-        return std::numeric_limits<std::size_t>::infinity();
+        return std::numeric_limits<std::size_t>::max();
     }
 
     static constexpr std::size_t access_id(
@@ -68,7 +68,7 @@ struct TensorIdentityIndex
 
     static constexpr std::size_t access_id_to_mem_id(std::size_t access_id)
     {
-        return std::numeric_limits<std::size_t>::infinity();
+        return std::numeric_limits<std::size_t>::max();
     }
 
     template <class Tensor, class Elem, class Id>

--- a/include/similie/tensor/levi_civita_tensor.hpp
+++ b/include/similie/tensor/levi_civita_tensor.hpp
@@ -55,7 +55,7 @@ struct TensorLeviCivitaIndex
     static constexpr std::size_t mem_id(
             std::array<std::size_t, sizeof...(TensorIndex)> const natural_ids)
     {
-        return std::numeric_limits<std::size_t>::infinity();
+        return std::numeric_limits<std::size_t>::max();
     }
 
     static constexpr std::size_t access_id(
@@ -73,7 +73,7 @@ struct TensorLeviCivitaIndex
 
     static constexpr std::size_t access_id_to_mem_id(std::size_t access_id)
     {
-        return std::numeric_limits<std::size_t>::infinity();
+        return std::numeric_limits<std::size_t>::max();
     }
 
     template <class Tensor, class Elem, class Id>

--- a/include/similie/tensor/levi_civita_tensor.hpp
+++ b/include/similie/tensor/levi_civita_tensor.hpp
@@ -18,6 +18,7 @@ template <class... TensorIndex>
 struct TensorLeviCivitaIndex
 {
     static constexpr bool is_tensor_index = true;
+    static constexpr bool is_explicitely_stored_tensor = true;
 
     using subindices_domain_t = ddc::DiscreteDomain<TensorIndex...>;
 
@@ -51,18 +52,16 @@ struct TensorLeviCivitaIndex
         return 3;
     }
 
-    static constexpr std::pair<std::vector<double>, std::vector<std::size_t>> mem_lin_comb(
-            std::array<std::size_t, sizeof...(TensorIndex)> const ids)
+    static constexpr std::size_t mem_id(
+            std::array<std::size_t, sizeof...(TensorIndex)> const natural_ids)
     {
-        return std::pair<
-                std::vector<double>,
-                std::vector<std::size_t>>(std::vector<double> {}, std::vector<std::size_t> {});
+        return std::numeric_limits<std::size_t>::infinity();
     }
 
     static constexpr std::size_t access_id(
-            std::array<std::size_t, sizeof...(TensorIndex)> const ids)
+            std::array<std::size_t, sizeof...(TensorIndex)> const natural_ids)
     {
-        int const parity = misc::permutation_parity(ids);
+        int const parity = misc::permutation_parity(natural_ids);
         if (parity == 0) {
             return 0;
         } else if (parity == 1) {
@@ -72,12 +71,9 @@ struct TensorLeviCivitaIndex
         }
     }
 
-    static constexpr std::pair<std::vector<double>, std::vector<std::size_t>>
-    access_id_to_mem_lin_comb(std::size_t access_id)
+    static constexpr std::size_t access_id_to_mem_id(std::size_t access_id)
     {
-        return std::pair<
-                std::vector<double>,
-                std::vector<std::size_t>>(std::vector<double> {}, std::vector<std::size_t> {});
+        return std::numeric_limits<std::size_t>::infinity();
     }
 
     template <class Tensor, class Elem, class Id>

--- a/include/similie/tensor/lorentzian_sign_tensor.hpp
+++ b/include/similie/tensor/lorentzian_sign_tensor.hpp
@@ -51,7 +51,7 @@ struct TensorLorentzianSignIndex
     static constexpr std::size_t mem_id(
             std::array<std::size_t, sizeof...(TensorIndex)> const natural_ids)
     {
-        return std::numeric_limits<std::size_t>::infinity();
+        return std::numeric_limits<std::size_t>::max();
     }
 
     static constexpr std::size_t access_id(
@@ -72,7 +72,7 @@ struct TensorLorentzianSignIndex
 
     static constexpr std::size_t access_id_to_mem_id(std::size_t access_id)
     {
-        return std::numeric_limits<std::size_t>::infinity();
+        return std::numeric_limits<std::size_t>::max();
     }
 
     template <class Tensor, class Elem, class Id>

--- a/include/similie/tensor/lorentzian_sign_tensor.hpp
+++ b/include/similie/tensor/lorentzian_sign_tensor.hpp
@@ -16,6 +16,7 @@ template <class Q, class... TensorIndex>
 struct TensorLorentzianSignIndex
 {
     static constexpr bool is_tensor_index = true;
+    static constexpr bool is_explicitely_stored_tensor = true;
 
     using subindices_domain_t = ddc::DiscreteDomain<TensorIndex...>;
 
@@ -47,23 +48,21 @@ struct TensorLorentzianSignIndex
         return 3;
     }
 
-    static constexpr std::pair<std::vector<double>, std::vector<std::size_t>> mem_lin_comb(
-            std::array<std::size_t, sizeof...(TensorIndex)> const ids)
+    static constexpr std::size_t mem_id(
+            std::array<std::size_t, sizeof...(TensorIndex)> const natural_ids)
     {
-        return std::pair<
-                std::vector<double>,
-                std::vector<std::size_t>>(std::vector<double> {}, std::vector<std::size_t> {});
+        return std::numeric_limits<std::size_t>::infinity();
     }
 
     static constexpr std::size_t access_id(
-            std::array<std::size_t, sizeof...(TensorIndex)> const ids)
+            std::array<std::size_t, sizeof...(TensorIndex)> const natural_ids)
     {
-        if (!std::all_of(ids.begin(), ids.end(), [&](const std::size_t id) {
-                return id == *ids.begin();
+        if (!std::all_of(natural_ids.begin(), natural_ids.end(), [&](const std::size_t id) {
+                return id == *natural_ids.begin();
             })) {
             return 0;
         } else {
-            if (ids[0] < Q::value) {
+            if (natural_ids[0] < Q::value) {
                 return 1;
             } else {
                 return 2;
@@ -71,12 +70,9 @@ struct TensorLorentzianSignIndex
         }
     }
 
-    static constexpr std::pair<std::vector<double>, std::vector<std::size_t>>
-    access_id_to_mem_lin_comb(std::size_t access_id)
+    static constexpr std::size_t access_id_to_mem_id(std::size_t access_id)
     {
-        return std::pair<
-                std::vector<double>,
-                std::vector<std::size_t>>(std::vector<double> {}, std::vector<std::size_t> {});
+        return std::numeric_limits<std::size_t>::infinity();
     }
 
     template <class Tensor, class Elem, class Id>

--- a/include/similie/tensor/symmetric_tensor.hpp
+++ b/include/similie/tensor/symmetric_tensor.hpp
@@ -18,6 +18,7 @@ template <class... TensorIndex>
 struct TensorSymmetricIndex
 {
     static constexpr bool is_tensor_index = true;
+    static constexpr bool is_explicitely_stored_tensor = true;
 
     using subindices_domain_t = ddc::DiscreteDomain<TensorIndex...>;
 
@@ -52,54 +53,45 @@ struct TensorSymmetricIndex
         return mem_size();
     }
 
-    static constexpr std::pair<std::vector<double>, std::vector<std::size_t>> mem_lin_comb(
-            std::array<std::size_t, rank()> const ids)
+    static constexpr std::size_t mem_id(std::array<std::size_t, rank()> const natural_ids)
     {
-        std::array<std::size_t, rank()> sorted_ids(ids);
+        std::array<std::size_t, rank()> sorted_ids(natural_ids);
         std::sort(sorted_ids.begin(), sorted_ids.end());
-        return std::pair<std::vector<double>, std::vector<std::size_t>>(
-                std::vector<double> {1.},
-                std::vector<std::size_t> {static_cast<std::size_t>(
-                        misc::binomial_coefficient(
-                                ddc::type_seq_element_t<0, ddc::detail::TypeSeq<TensorIndex...>>::
-                                                mem_size()
-                                        + rank() - 1,
-                                rank())
-                        - ((sorted_ids[ddc::type_seq_rank_v<
-                                    TensorIndex,
-                                    ddc::detail::TypeSeq<TensorIndex...>>]
-                                            == TensorIndex::mem_size() - 1
-                                    ? 0
-                                    : misc::binomial_coefficient(
-                                              TensorIndex::mem_size()
-                                                      - sorted_ids[ddc::type_seq_rank_v<
-                                                              TensorIndex,
-                                                              ddc::detail::TypeSeq<TensorIndex...>>]
-                                                      + rank()
-                                                      - ddc::type_seq_rank_v<
-                                                              TensorIndex,
-                                                              ddc::detail::TypeSeq<TensorIndex...>>
-                                                      - 2,
-                                              rank()
-                                                      - ddc::type_seq_rank_v<
-                                                              TensorIndex,
-                                                              ddc::detail::TypeSeq<
-                                                                      TensorIndex...>>))
-                           + ...)
-                        - 1)});
+        return misc::binomial_coefficient(
+                       ddc::type_seq_element_t<0, ddc::detail::TypeSeq<TensorIndex...>>::mem_size()
+                               + rank() - 1,
+                       rank())
+               - ((sorted_ids[ddc::type_seq_rank_v<
+                           TensorIndex,
+                           ddc::detail::TypeSeq<TensorIndex...>>]
+                                   == TensorIndex::mem_size() - 1
+                           ? 0
+                           : misc::binomial_coefficient(
+                                     TensorIndex::mem_size()
+                                             - sorted_ids[ddc::type_seq_rank_v<
+                                                     TensorIndex,
+                                                     ddc::detail::TypeSeq<TensorIndex...>>]
+                                             + rank()
+                                             - ddc::type_seq_rank_v<
+                                                     TensorIndex,
+                                                     ddc::detail::TypeSeq<TensorIndex...>>
+                                             - 2,
+                                     rank()
+                                             - ddc::type_seq_rank_v<
+                                                     TensorIndex,
+                                                     ddc::detail::TypeSeq<TensorIndex...>>))
+                  + ...)
+               - 1;
     }
 
-    static constexpr std::size_t access_id(std::array<std::size_t, rank()> const ids)
+    static constexpr std::size_t access_id(std::array<std::size_t, rank()> const natural_ids)
     {
-        return std::get<1>(mem_lin_comb(ids))[0];
+        return mem_id(natural_ids);
     }
 
-    static constexpr std::pair<std::vector<double>, std::vector<std::size_t>>
-    access_id_to_mem_lin_comb(std::size_t access_id)
+    static constexpr std::size_t access_id_to_mem_id(std::size_t access_id)
     {
-        return std::pair<std::vector<double>, std::vector<std::size_t>>(
-                std::vector<double> {1.},
-                std::vector<std::size_t> {access_id});
+        return access_id;
     }
 
     template <class Tensor, class Elem, class Id>

--- a/include/similie/tensor/tensor_impl.hpp
+++ b/include/similie/tensor/tensor_impl.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include <cmath>
 #include <iostream>
 
 #include <ddc/ddc.hpp>

--- a/include/similie/tensor/tensor_impl.hpp
+++ b/include/similie/tensor/tensor_impl.hpp
@@ -3,6 +3,9 @@
 
 #pragma once
 
+#include <cmath>
+#include <iostream>
+
 #include <ddc/ddc.hpp>
 
 #include <similie/misc/specialization.hpp>
@@ -17,6 +20,7 @@ struct TensorNaturalIndex
 {
     static constexpr bool is_tensor_index = true;
     static constexpr bool is_tensor_natural_index = true;
+    static constexpr bool is_explicitely_stored_tensor = true;
 
     using type_seq_dimensions = ddc::detail::TypeSeq<CDim...>;
 
@@ -52,39 +56,28 @@ struct TensorNaturalIndex
     }
 
     template <class ODim>
-    static constexpr std::pair<std::vector<double>, std::vector<std::size_t>> mem_lin_comb()
+    static constexpr std::size_t mem_id()
     {
         if constexpr (rank() == 0) {
-            return std::pair<
-                    std::vector<double>,
-                    std::vector<
-                            std::size_t>>(std::vector<double> {1.}, std::vector<std::size_t> {0});
+            return 0;
         } else {
-            return std::pair<std::vector<double>, std::vector<std::size_t>>(
-                    std::vector<double> {1.},
-                    std::vector<std::size_t> {ddc::type_seq_rank_v<ODim, type_seq_dimensions>});
+            return ddc::type_seq_rank_v<ODim, type_seq_dimensions>;
         }
     }
 
-    static constexpr std::pair<std::vector<double>, std::vector<std::size_t>> mem_lin_comb(
-            std::size_t const id)
+    static constexpr std::size_t mem_id(std::size_t const natural_id)
     {
-        return std::pair<
-                std::vector<double>,
-                std::vector<std::size_t>>(std::vector<double> {1.}, std::vector<std::size_t> {id});
+        return natural_id;
     }
 
-    static constexpr std::size_t access_id(std::size_t const id)
+    static constexpr std::size_t access_id(std::size_t const natural_id)
     {
-        return id;
+        return natural_id;
     }
 
-    static constexpr std::pair<std::vector<double>, std::vector<std::size_t>>
-    access_id_to_mem_lin_comb(std::size_t access_id)
+    static constexpr std::size_t access_id_to_mem_id(std::size_t access_id)
     {
-        return std::pair<std::vector<double>, std::vector<std::size_t>>(
-                std::vector<double> {1.},
-                std::vector<std::size_t> {access_id});
+        return access_id;
     }
 
     template <class Tensor, class Elem, class Id>
@@ -443,24 +436,42 @@ struct Access<TensorField, Element, ddc::detail::TypeSeq<IndexHead...>, IndexInt
             if constexpr (TensorIndex<IndexInterest>) {
                 return IndexInterest::template process_access<TensorField, Elem, IndexInterest>(
                         [](TensorField tensor_field_, Elem elem_) -> TensorField::element_type {
-                            std::pair<std::vector<double>, std::vector<std::size_t>> mem_lin_comb
-                                    = IndexInterest::access_id_to_mem_lin_comb(
-                                            elem_.template uid<IndexInterest>());
-
                             double tensor_field_value = 0;
-                            if (std::get<0>(mem_lin_comb).size() > 0) {
-                                for (std::size_t i = 0; i < std::get<0>(mem_lin_comb).size(); ++i) {
+                            if constexpr (IndexInterest::is_explicitely_stored_tensor) {
+                                std::size_t const mem_id = IndexInterest::access_id_to_mem_id(
+                                        elem_.template uid<IndexInterest>());
+                                if (mem_id != std::numeric_limits<std::size_t>::infinity()) {
                                     tensor_field_value
-                                            += std::get<0>(mem_lin_comb)[i]
-                                               * tensor_field_
-                                                         .mem(ddc::DiscreteElement<IndexHead...>(
-                                                                      elem_),
-                                                              ddc::DiscreteElement<IndexInterest>(
-                                                                      std::get<1>(
-                                                                              mem_lin_comb)[i]));
+                                            = tensor_field_
+                                                      .mem(ddc::DiscreteElement<IndexHead...>(
+                                                                   elem_),
+                                                           ddc::DiscreteElement<IndexInterest>(
+                                                                   mem_id));
+                                } else {
+                                    tensor_field_value = 1.;
                                 }
                             } else {
-                                tensor_field_value = 1.;
+                                std::pair<std::vector<double>, std::vector<std::size_t>> const
+                                        mem_lin_comb
+                                        = IndexInterest::access_id_to_mem_lin_comb(
+                                                elem_.template uid<IndexInterest>());
+
+                                if (std::get<0>(mem_lin_comb).size() > 0) {
+                                    for (std::size_t i = 0; i < std::get<0>(mem_lin_comb).size();
+                                         ++i) {
+                                        tensor_field_value
+                                                += std::get<0>(mem_lin_comb)[i]
+                                                   * tensor_field_
+                                                             .mem(ddc::DiscreteElement<
+                                                                          IndexHead...>(elem_),
+                                                                  ddc::DiscreteElement<
+                                                                          IndexInterest>(std::get<
+                                                                                         1>(
+                                                                          mem_lin_comb)[i]));
+                                    }
+                                } else {
+                                    tensor_field_value = 1.;
+                                }
                             }
 
                             return tensor_field_value;
@@ -491,13 +502,21 @@ struct LambdaMemElem<InterestDim>
     template <class Elem>
     static ddc::DiscreteElement<InterestDim> run(Elem elem)
     {
-        std::pair<std::vector<double>, std::vector<std::size_t>> mem_lin_comb
-                = InterestDim::access_id_to_mem_lin_comb(elem.template uid<InterestDim>());
-        assert(std::get<0>(mem_lin_comb).size() > 0
-               && "mem_elem is not defined because mem_lin_comb contains no id");
-        assert(std::get<0>(mem_lin_comb).size() == 1
-               && "mem_elem is not defined because mem_lin_comb contains several ids");
-        return ddc::DiscreteElement<InterestDim>(std::get<1>(mem_lin_comb)[0]);
+        if constexpr (InterestDim::is_explicitely_stored_tensor) {
+            std::size_t const mem_id
+                    = InterestDim::access_id_to_mem_id(elem.template uid<InterestDim>());
+            assert(mem_id != std::numeric_limits<std::size_t>::infinity()
+                   && "mem_elem is not defined because mem_id() returned an infinity");
+            return ddc::DiscreteElement<InterestDim>(mem_id);
+        } else {
+            std::pair<std::vector<double>, std::vector<std::size_t>> const mem_lin_comb
+                    = InterestDim::access_id_to_mem_lin_comb(elem.template uid<InterestDim>());
+            assert(std::get<0>(mem_lin_comb).size() > 0
+                   && "mem_elem is not defined because mem_lin_comb contains no id");
+            assert(std::get<0>(mem_lin_comb).size() == 1
+                   && "mem_elem is not defined because mem_lin_comb contains several ids");
+            return ddc::DiscreteElement<InterestDim>(std::get<1>(mem_lin_comb)[0]);
+        }
     }
 };
 

--- a/include/similie/tensor/tensor_impl.hpp
+++ b/include/similie/tensor/tensor_impl.hpp
@@ -440,7 +440,7 @@ struct Access<TensorField, Element, ddc::detail::TypeSeq<IndexHead...>, IndexInt
                             if constexpr (IndexInterest::is_explicitely_stored_tensor) {
                                 std::size_t const mem_id = IndexInterest::access_id_to_mem_id(
                                         elem_.template uid<IndexInterest>());
-                                if (mem_id != std::numeric_limits<std::size_t>::infinity()) {
+                                if (mem_id != std::numeric_limits<std::size_t>::max()) {
                                     tensor_field_value
                                             = tensor_field_
                                                       .mem(ddc::DiscreteElement<IndexHead...>(
@@ -505,8 +505,8 @@ struct LambdaMemElem<InterestDim>
         if constexpr (InterestDim::is_explicitely_stored_tensor) {
             std::size_t const mem_id
                     = InterestDim::access_id_to_mem_id(elem.template uid<InterestDim>());
-            assert(mem_id != std::numeric_limits<std::size_t>::infinity()
-                   && "mem_elem is not defined because mem_id() returned an infinity");
+            assert(mem_id != std::numeric_limits<std::size_t>::max()
+                   && "mem_elem is not defined because mem_id() returned a max integer");
             return ddc::DiscreteElement<InterestDim>(mem_id);
         } else {
             std::pair<std::vector<double>, std::vector<std::size_t>> const mem_lin_comb

--- a/include/similie/tensor/young_tableau_tensor.hpp
+++ b/include/similie/tensor/young_tableau_tensor.hpp
@@ -20,6 +20,7 @@ template <class YoungTableau, class... TensorIndex>
 struct TensorYoungTableauIndex
 {
     static constexpr bool is_tensor_index = true;
+    static constexpr bool is_explicitely_stored_tensor = false;
 
     using young_tableau = YoungTableau;
 

--- a/include/similie/tensor/young_tableau_tensor.hpp
+++ b/include/similie/tensor/young_tableau_tensor.hpp
@@ -55,7 +55,7 @@ struct TensorYoungTableauIndex
     }
 
     static constexpr std::pair<std::vector<double>, std::vector<std::size_t>> mem_lin_comb(
-            std::array<std::size_t, sizeof...(TensorIndex)> const ids)
+            std::array<std::size_t, sizeof...(TensorIndex)> const natural_ids)
     {
         std::pair<std::vector<double>, std::vector<std::size_t>> result {};
         constexpr csr::Csr v = young_tableau::template v<
@@ -67,7 +67,7 @@ struct TensorYoungTableauIndex
         for (std::size_t j = 0; j < v.values().size(); ++j) {
             if (((v.idx()[ddc::type_seq_rank_v<TensorIndex, ddc::detail::TypeSeq<TensorIndex...>>]
                          [j]
-                  == TensorIndex::access_id(ids))
+                  == TensorIndex::access_id(natural_ids))
                  && ...)) {
                 std::get<0>(result).push_back(v.values()[j]);
                 std::size_t k = 0;
@@ -81,10 +81,11 @@ struct TensorYoungTableauIndex
     }
 
     static constexpr std::size_t access_id(
-            std::array<std::size_t, sizeof...(TensorIndex)> const ids)
+            std::array<std::size_t, sizeof...(TensorIndex)> const natural_ids)
     {
         return ((misc::detail::stride<TensorIndex, TensorIndex...>()
-                 * ids[ddc::type_seq_rank_v<TensorIndex, ddc::detail::TypeSeq<TensorIndex...>>])
+                 * natural_ids
+                         [ddc::type_seq_rank_v<TensorIndex, ddc::detail::TypeSeq<TensorIndex...>>])
                 + ...);
     }
 


### PR DESCRIPTION
- Use a constexpr flag `is_explicitely_stored_tensor` to simplify all tensor indexes except YoungTableau one
- Minor terminology