### PR TITLE
Exterior module extract Kokkos::View allocations

### DIFF
--- a/.devnote
+++ b/.devnote
@@ -21,7 +21,6 @@ SPDX-License-Identifier: GPL-3.0-or-later
 - is_same_character_v and use it in tensor product
 - find a way to use CTAD when constructing a Tensor and DiscreteDomain
 - Avoid usage of std::array in non-constexpr tensor_impl function (exclusive to YoungTableauIndexing)
-- Cochain should not be template with execspace
 
 ----- SETUP BASIC COMMAND -----
 

--- a/.devnote
+++ b/.devnote
@@ -21,7 +21,6 @@ SPDX-License-Identifier: GPL-3.0-or-later
 - is_same_character_v and use it in tensor product
 - find a way to use CTAD when constructing a Tensor and DiscreteDomain
 - Avoid usage of std::array in non-constexpr tensor_impl function (exclusive to YoungTableauIndexing)
-- Rename chain::push_back() -> chain::operator=+ 
 
 ----- SETUP BASIC COMMAND -----
 

--- a/.devnote
+++ b/.devnote
@@ -21,6 +21,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
 - is_same_character_v and use it in tensor product
 - find a way to use CTAD when constructing a Tensor and DiscreteDomain
 - Avoid usage of std::array in non-constexpr tensor_impl function (exclusive to YoungTableauIndexing)
+- Cochain should not be template with execspace
 
 ----- SETUP BASIC COMMAND -----
 

--- a/.devnote
+++ b/.devnote
@@ -21,7 +21,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
 - is_same_character_v and use it in tensor product
 - find a way to use CTAD when constructing a Tensor and DiscreteDomain
 - Avoid usage of std::array in non-constexpr tensor_impl function (exclusive to YoungTableauIndexing)
-- Kokkos::View constructors performing an allocation are not KOKKOS_FUNCTION
+- Rename chain::push_back() -> chain::operator=+ 
 
 ----- SETUP BASIC COMMAND -----
 

--- a/include/similie/exterior/boundary.hpp
+++ b/include/similie/exterior/boundary.hpp
@@ -46,7 +46,7 @@ KOKKOS_FUNCTION constexpr Chain<boundary_t<SimplexType>> generate_half_subchain(
         bool negative = false)
 {
     auto array = ddc::detail::array(vect);
-    Chain<boundary_t<SimplexType>> chain(allocation, allocation.size());
+    Chain<boundary_t<SimplexType>> chain(allocation);
     auto id_dist = -1;
     for (std::size_t i = 0; i < SimplexType::dimension(); ++i) {
         auto array_ = array;
@@ -56,7 +56,7 @@ KOKKOS_FUNCTION constexpr Chain<boundary_t<SimplexType>> generate_half_subchain(
         *id = 0;
         typename SimplexType::discrete_vector_type vect_;
         ddc::detail::array(vect_) = array_;
-        chain[i] = boundary_t<SimplexType>(elem, vect_, (negative + i) % 2);
+        chain += boundary_t<SimplexType>(elem, vect_, (negative + i) % 2);
         j = id + 1;
     }
     return chain;

--- a/include/similie/exterior/boundary.hpp
+++ b/include/similie/exterior/boundary.hpp
@@ -38,14 +38,15 @@ using boundary_t = typename detail::BoundaryType<T>::type;
 namespace detail {
 
 // TODO Kokkosify
-template <class SimplexType>
+template <class SimplexType, misc::Specialization<Kokkos::View> AllocationType>
 KOKKOS_FUNCTION constexpr Chain<boundary_t<SimplexType>> generate_half_subchain(
+        AllocationType allocation,
         typename SimplexType::discrete_element_type elem,
         typename SimplexType::discrete_vector_type vect,
         bool negative = false)
 {
     auto array = ddc::detail::array(vect);
-    Chain<boundary_t<SimplexType>> chain;
+    Chain<boundary_t<SimplexType>> chain(allocation, allocation.size());
     auto id_dist = -1;
     for (std::size_t i = 0; i < SimplexType::dimension(); ++i) {
         auto array_ = array;
@@ -55,7 +56,7 @@ KOKKOS_FUNCTION constexpr Chain<boundary_t<SimplexType>> generate_half_subchain(
         *id = 0;
         typename SimplexType::discrete_vector_type vect_;
         ddc::detail::array(vect_) = array_;
-        chain.push_back(boundary_t<SimplexType>(elem, vect_, (negative + i) % 2));
+        chain[i] = boundary_t<SimplexType>(elem, vect_, (negative + i) % 2);
         j = id + 1;
     }
     return chain;
@@ -63,29 +64,49 @@ KOKKOS_FUNCTION constexpr Chain<boundary_t<SimplexType>> generate_half_subchain(
 
 } // namespace detail
 
-template <class SimplexType>
-KOKKOS_FUNCTION Chain<boundary_t<SimplexType>> boundary(SimplexType simplex)
+template <misc::Specialization<Kokkos::View> AllocationType, class SimplexType>
+KOKKOS_FUNCTION Chain<boundary_t<SimplexType>> boundary(
+        AllocationType allocation,
+        SimplexType simplex)
 {
-    return Chain<boundary_t<SimplexType>>(
-                   detail::generate_half_subchain<SimplexType>(
-                           simplex.discrete_element(),
-                           simplex.discrete_vector(),
-                           SimplexType::dimension() % 2)
-                   + detail::generate_half_subchain<SimplexType>(
-                           simplex.discrete_element() + simplex.discrete_vector(),
-                           -simplex.discrete_vector()))
-           * (SimplexType::dimension() % 2 ? 1 : -1) * (simplex.negative() ? -1 : 1);
+    Chain<boundary_t<SimplexType>> chain(allocation);
+    detail::generate_half_subchain<SimplexType>(
+            Kokkos::
+                    subview(allocation,
+                            std::pair<std::size_t, std::size_t>(0, SimplexType::dimension())),
+            simplex.discrete_element(),
+            simplex.discrete_vector(),
+            SimplexType::dimension() % 2);
+    chain += SimplexType::dimension();
+    detail::generate_half_subchain<SimplexType>(
+            Kokkos::
+                    subview(allocation,
+                            std::pair<std::size_t, std::size_t>(
+                                    SimplexType::dimension(),
+                                    2 * SimplexType::dimension())),
+            simplex.discrete_element() + simplex.discrete_vector(),
+            -simplex.discrete_vector());
+    chain += SimplexType::dimension();
+    chain *= (SimplexType::dimension() % 2 ? 1 : -1) * (simplex.negative() ? -1 : 1);
+    return chain;
 }
 
-template <class SimplexType>
-KOKKOS_FUNCTION Chain<boundary_t<SimplexType>> boundary(Chain<SimplexType> chain)
+template <misc::Specialization<Kokkos::View> AllocationType, class SimplexType>
+KOKKOS_FUNCTION Chain<boundary_t<SimplexType>> boundary(
+        AllocationType allocation,
+        Chain<SimplexType> chain)
 {
-    Chain<boundary_t<SimplexType>> boundary_chain;
-    for (auto& simplex : chain) {
-        Chain<boundary_t<SimplexType>> boundary_simplex = boundary(simplex);
-        for (auto& simplex_ : boundary_simplex) {
-            boundary_chain.push_back(simplex_);
-        }
+    Chain<boundary_t<SimplexType>> boundary_chain(allocation);
+    for (auto i = chain.begin(); i < chain.end(); ++i) {
+        std::size_t const distance = Kokkos::Experimental::distance(chain.begin(), i);
+        boundary(
+                Kokkos::
+                        subview(allocation,
+                                std::pair<std::size_t, std::size_t>(
+                                        2 * SimplexType::dimension() * distance,
+                                        2 * SimplexType::dimension() * (distance + 1))),
+                *i);
+        boundary_chain += 2 * SimplexType::dimension();
     }
     boundary_chain.optimize();
     return boundary_chain;

--- a/include/similie/exterior/chain.hpp
+++ b/include/similie/exterior/chain.hpp
@@ -17,7 +17,10 @@ namespace sil {
 namespace exterior {
 
 /// Chain class
-template <class SimplexType, class ExecSpace = Kokkos::DefaultHostExecutionSpace>
+template <
+        class SimplexType,
+        class LayoutStridedPolicy = Kokkos::LayoutRight,
+        class ExecSpace = Kokkos::DefaultHostExecutionSpace>
 class Chain
 {
 public:
@@ -25,7 +28,7 @@ public:
     using memory_space = typename ExecSpace::memory_space;
 
     using simplex_type = SimplexType;
-    using simplices_type = Kokkos::View<SimplexType*, memory_space>;
+    using simplices_type = Kokkos::View<SimplexType*, LayoutStridedPolicy, memory_space>;
     using discrete_element_type = typename simplex_type::discrete_element_type;
     using discrete_vector_type = typename simplex_type::discrete_vector_type;
 

--- a/include/similie/exterior/chain.hpp
+++ b/include/similie/exterior/chain.hpp
@@ -275,9 +275,9 @@ public:
     template <class T>
     KOKKOS_FUNCTION auto operator*(T t)
     {
-        simplices_type simplices = m_simplices;
-        simplices *= t;
-        return simplices;
+        Chain<simplex_type> chain = *this;
+        chain *= t;
+        return chain;
     }
 
     KOKKOS_FUNCTION bool operator==(Chain<simplex_type> simplices)

--- a/include/similie/exterior/chain.hpp
+++ b/include/similie/exterior/chain.hpp
@@ -46,6 +46,7 @@ public:
     KOKKOS_DEFAULTED_FUNCTION constexpr Chain(Chain&&) = default;
 
     template <class... T>
+        requires(!std::is_convertible_v<T, std::size_t> && ...)
     KOKKOS_FUNCTION constexpr explicit Chain(simplices_type allocation, T... simplex) noexcept
         : m_simplices(std::move(allocation))
         , m_size(sizeof...(T))

--- a/include/similie/exterior/chain.hpp
+++ b/include/similie/exterior/chain.hpp
@@ -35,7 +35,8 @@ private:
     static constexpr bool s_is_local = false;
     static constexpr std::size_t s_k = simplex_type::dimension();
     simplices_type m_simplices;
-    std::size_t m_size; // Effective size, not necessarily equal to m_simplices.size()
+    std::size_t
+            m_size; // Effective size, m_simplices elements between m_size and m_simplices.size() are undefined
 
 public:
     KOKKOS_DEFAULTED_FUNCTION constexpr Chain() = default;
@@ -46,7 +47,7 @@ public:
 
     template <class... T>
     KOKKOS_FUNCTION constexpr explicit Chain(simplices_type allocation, T... simplex) noexcept
-        : m_simplices(allocation) // TODO std::move ?
+        : m_simplices(std::move(allocation))
         , m_size(sizeof...(T))
     {
         std::size_t i = 0;
@@ -55,7 +56,7 @@ public:
     }
 
     KOKKOS_FUNCTION constexpr explicit Chain(simplices_type allocation, std::size_t size) noexcept
-        : m_simplices(allocation)
+        : m_simplices(std::move(allocation))
         , m_size(size)
     {
         assert(check() == 0 && "there are duplicate simplices in the chain");

--- a/include/similie/exterior/coboundary.hpp
+++ b/include/similie/exterior/coboundary.hpp
@@ -255,7 +255,7 @@ coboundary_tensor_t<TagToAddToCochain, CochainTag, TensorType> coboundary(
                     TagToAddToCochain,
                     typename TensorType::non_indices_domain_t>::type>();
 
-    // compute the tangent K+1-basis for each node of the mesh. This is a local K-chain.
+    // compute the tangent K-basis for each node of the mesh. This is a local K-chain.
     auto lower_chain = tangent_basis<
             CochainTag::rank(),
             typename detail::NonSpectatorDimension<

--- a/include/similie/exterior/coboundary.hpp
+++ b/include/similie/exterior/coboundary.hpp
@@ -254,6 +254,7 @@ coboundary_tensor_t<TagToAddToCochain, CochainTag, TensorType> coboundary(
             typename detail::NonSpectatorDimension<
                     TagToAddToCochain,
                     typename TensorType::non_indices_domain_t>::type>();
+
     // compute the tangent K+1-basis for each node of the mesh. This is a local K-chain.
     auto lower_chain = tangent_basis<
             CochainTag::rank(),

--- a/include/similie/exterior/coboundary.hpp
+++ b/include/similie/exterior/coboundary.hpp
@@ -203,13 +203,18 @@ KOKKOS_FUNCTION coboundary_tensor_t<TagToAddToCochain, CochainTag, TensorType> c
                                 typename TensorType::non_indices_domain_t>::type>();
                 auto cochain = Cochain(chain, coboundary_tensor[elem]);
                 for (auto i = cochain.begin(); i < cochain.end(); ++i) {
+                    auto simplex = Simplex(
+                            std::integral_constant<std::size_t, CochainTag::rank() + 1> {},
+                            elem,
+                            (*i).discrete_vector());
+                    Kokkos::View<
+                            decltype(Simplex(
+                                    std::integral_constant<std::size_t, CochainTag::rank()> {},
+                                    elem))*,
+                            Kokkos::HostSpace>
+                            simplex_boundary_alloc("simplex_boundary", 2 * CochainTag::rank());
                     sil::exterior::Chain simplex_boundary
-                            = boundary(sil::exterior::
-                                               Simplex(std::integral_constant<
-                                                               std::size_t,
-                                                               CochainTag::rank() + 1> {},
-                                                       elem,
-                                                       (*i).discrete_vector()));
+                            = boundary(simplex_boundary_alloc, simplex);
                     Kokkos::View<double*, Kokkos::HostSpace>
                             values("coboundary_values", simplex_boundary.size());
                     for (auto j = simplex_boundary.begin(); j < simplex_boundary.end(); ++j) {

--- a/include/similie/exterior/coboundary.hpp
+++ b/include/similie/exterior/coboundary.hpp
@@ -207,7 +207,7 @@ coboundary_tensor_t<TagToAddToCochain, CochainTag, TensorType> coboundary(
             = ddc::remove_dims_of<coboundary_index_t<TagToAddToCochain, CochainTag>>(
                     coboundary_tensor.domain());
 
-    // buffer to store the chain containing the boundary of each K+1-simplex of the mesh
+    // buffer to store the K-chain containing the boundary of each K+1-simplex of the mesh
     ddc::Chunk simplex_boundary_alloc(
             ddc::cartesian_prod_t<
                     ddc::remove_dims_of_t<
@@ -231,7 +231,7 @@ coboundary_tensor_t<TagToAddToCochain, CochainTag, TensorType> coboundary(
                             coboundary_index_t<TagToAddToCochain, CochainTag>>>>());
     ddc::ChunkSpan simplex_boundary = simplex_boundary_alloc.span_view();
 
-    // buffer to store the values on the boundary of each K+1-cosimplex of the mesh
+    // buffer to store the values of the K-cochain on the boundary of each K+1-cosimplex of the mesh
     ddc::Chunk boundary_values_alloc(
             ddc::cartesian_prod_t<
                     ddc::remove_dims_of_t<

--- a/include/similie/exterior/coboundary.hpp
+++ b/include/similie/exterior/coboundary.hpp
@@ -302,7 +302,7 @@ coboundary_tensor_t<TagToAddToCochain, CochainTag, TensorType> coboundary(
                             boundary_chain,
                             boundary_values[elem].allocation_kokkos_view());
                     // integrate over the cochain forming the boundary to compute the coboundary
-                    // (*i).value() = cochain_boundary.integrate(); // Cannot be used bevause CochainIterator::operator* does not return a reference
+                    // (*i).value() = cochain_boundary.integrate(); // Cannot be used because CochainIterator::operator* does not return a reference
                     coboundary_tensor
                             .mem(elem,
                                  ddc::DiscreteElement<

--- a/include/similie/exterior/coboundary.hpp
+++ b/include/similie/exterior/coboundary.hpp
@@ -236,6 +236,7 @@ coboundary_tensor_t<TagToAddToCochain, CochainTag, TensorType> coboundary(
     Kokkos::View<double*, Kokkos::LayoutRight, Kokkos::HostSpace>
             values("coboundary_values", 2 * (CochainTag::rank() + 1));
 
+    // TODO fix race condition
     // process
     ddc::parallel_for_each(
             Kokkos::DefaultHostExecutionSpace(),

--- a/include/similie/exterior/coboundary.hpp
+++ b/include/similie/exterior/coboundary.hpp
@@ -28,11 +28,24 @@ namespace detail {
 template <class T>
 struct CoboundaryType;
 
-template <std::size_t K, class... Tag, class ElementType, class Allocator>
-struct CoboundaryType<Cochain<Chain<Simplex<K, Tag...>>, ElementType, Allocator>>
+template <std::size_t K, class... Tag, class ElementType, class ExecSpace>
+struct CoboundaryType<Cochain<Chain<Simplex<K, Tag...>>, ElementType, ExecSpace>>
 {
     using type = Cosimplex<Simplex<K + 1, Tag...>, ElementType>;
 };
+
+template <std::size_t K, class... Tag, class ElementType, class ExecSpace>
+struct CoboundaryType<Cochain<Chain<Simplex<K, Tag...>, ExecSpace>, ElementType, ExecSpace>>
+{
+    using type = Cosimplex<Simplex<K + 1, Tag...>, ElementType>;
+};
+
+} // namespace detail
+
+template <misc::Specialization<Cochain> CochainType>
+using coboundary_t = typename detail::CoboundaryType<CochainType>::type;
+
+namespace detail {
 
 template <class TagToAddToCochain, class CochainTag>
 struct CoboundaryIndex;
@@ -97,9 +110,6 @@ struct CoboundaryTensorType<
 
 } // namespace detail
 
-template <misc::Specialization<Cochain> CochainType>
-using coboundary_t = typename detail::CoboundaryType<CochainType>::type;
-
 template <
         tensor::TensorNatIndex TagToAddToCochain,
         tensor::TensorIndex CochainTag,
@@ -141,8 +151,10 @@ KOKKOS_FUNCTION coboundary_t<CochainType> coboundary(
     assert(cochain.size() == 2 * (cochain.dimension() + 1)
            && "only cochain over the boundary of a single simplex is supported");
 
+    /* Commented because would require an additional buffer
     assert(boundary(cochain.chain()) == boundary_t<typename CochainType::chain_type> {}
            && "only cochain over the boundary of a single simplex is supported");
+     */
 
     return coboundary_t<CochainType>(
             detail::ComputeSimplex<typename CochainType::chain_type>::run(cochain.chain()),

--- a/include/similie/exterior/coboundary.hpp
+++ b/include/similie/exterior/coboundary.hpp
@@ -211,11 +211,12 @@ KOKKOS_FUNCTION coboundary_tensor_t<TagToAddToCochain, CochainTag, TensorType> c
                             decltype(Simplex(
                                     std::integral_constant<std::size_t, CochainTag::rank()> {},
                                     elem))*,
+                            Kokkos::LayoutRight,
                             Kokkos::HostSpace>
-                            simplex_boundary_alloc("simplex_boundary", 2 * CochainTag::rank());
+                            simplex_boundary_alloc("simplex_boundary", 2 * simplex.size());
                     sil::exterior::Chain simplex_boundary
                             = boundary(simplex_boundary_alloc, simplex);
-                    Kokkos::View<double*, Kokkos::HostSpace>
+                    Kokkos::View<double*, Kokkos::LayoutRight, Kokkos::HostSpace>
                             values("coboundary_values", simplex_boundary.size());
                     for (auto j = simplex_boundary.begin(); j < simplex_boundary.end(); ++j) {
                         values(Kokkos::Experimental::distance(simplex_boundary.begin(), j))

--- a/include/similie/exterior/coboundary.hpp
+++ b/include/similie/exterior/coboundary.hpp
@@ -28,14 +28,23 @@ namespace detail {
 template <class T>
 struct CoboundaryType;
 
-template <std::size_t K, class... Tag, class ElementType, class ExecSpace>
-struct CoboundaryType<Cochain<Chain<Simplex<K, Tag...>>, ElementType, ExecSpace>>
+template <std::size_t K, class... Tag, class ElementType, class LayoutStridedPolicy>
+struct CoboundaryType<Cochain<Chain<Simplex<K, Tag...>>, ElementType, LayoutStridedPolicy>>
 {
     using type = Cosimplex<Simplex<K + 1, Tag...>, ElementType>;
 };
 
-template <std::size_t K, class... Tag, class ElementType, class ExecSpace>
-struct CoboundaryType<Cochain<Chain<Simplex<K, Tag...>, ExecSpace>, ElementType, ExecSpace>>
+template <
+        std::size_t K,
+        class... Tag,
+        class ElementType,
+        class LayoutStridedPolicy1,
+        class LayoutStridedPolicy2,
+        class ExecSpace>
+struct CoboundaryType<
+        Cochain<Chain<Simplex<K, Tag...>, LayoutStridedPolicy1, ExecSpace>,
+                ElementType,
+                LayoutStridedPolicy2>>
 {
     using type = Cosimplex<Simplex<K + 1, Tag...>, ElementType>;
 };

--- a/include/similie/exterior/coboundary.hpp
+++ b/include/similie/exterior/coboundary.hpp
@@ -217,9 +217,14 @@ KOKKOS_FUNCTION coboundary_tensor_t<TagToAddToCochain, CochainTag, TensorType> c
                             elem,
                             (*i).discrete_vector());
                     Kokkos::View<
-                            decltype(Simplex(
-                                    std::integral_constant<std::size_t, CochainTag::rank()> {},
-                                    elem))*,
+                            simplex_for_domain_t<
+                                    CochainTag::rank(),
+                                    ddc::remove_dims_of_t<
+                                            typename coboundary_tensor_t<
+                                                    TagToAddToCochain,
+                                                    CochainTag,
+                                                    TensorType>::discrete_domain_type,
+                                            coboundary_index_t<TagToAddToCochain, CochainTag>>>*,
                             Kokkos::LayoutRight,
                             Kokkos::HostSpace>
                             simplex_boundary_alloc("simplex_boundary", 2 * simplex.size());

--- a/include/similie/exterior/cochain.hpp
+++ b/include/similie/exterior/cochain.hpp
@@ -52,12 +52,6 @@ public:
 
     KOKKOS_DEFAULTED_FUNCTION constexpr Cochain(Cochain&&) = default;
 
-    KOKKOS_FUNCTION constexpr explicit Cochain(chain_type chain) noexcept
-        : m_chain(chain)
-        , m_values("", chain.size())
-    {
-    }
-
     template <class... T>
         requires(sizeof...(T) >= 1 && (std::is_convertible_v<T, double> && ...))
     KOKKOS_FUNCTION constexpr explicit Cochain(
@@ -98,14 +92,6 @@ public:
     {
         assert(m_values.size() == chain.size()
                && "cochain constructor must get as much values as the chain contains simplices");
-        /*
-        for (auto i = Kokkos::Experimental::begin(m_values);
-             i < Kokkos::Experimental::end(m_values);
-             ++i) {
-            *i = tensor.mem(ddc::DiscreteElement<Index>(
-                    Kokkos::Experimental::distance(Kokkos::Experimental::begin(m_values), i)));
-        }
-	*/
     }
 
     KOKKOS_DEFAULTED_FUNCTION ~Cochain() = default;

--- a/include/similie/exterior/cochain.hpp
+++ b/include/similie/exterior/cochain.hpp
@@ -81,8 +81,7 @@ public:
                && "cochain constructor must get as much values as the chain contains simplices");
     }
 
-    template <
-            tensor::TensorIndex Index>
+    template <tensor::TensorIndex Index, class OLayoutStridedPolicy>
         requires(misc::Specialization<Index, tensor::TensorAntisymmetricIndex>
                  || tensor::TensorNatIndex<Index>)
     KOKKOS_FUNCTION constexpr explicit Cochain(
@@ -90,7 +89,7 @@ public:
             tensor::Tensor<
                     element_type,
                     ddc::DiscreteDomain<Index>,
-                    LayoutStridedPolicy,
+                    OLayoutStridedPolicy,
                     memory_space> tensor) noexcept
         : m_chain(std::move(chain))
         // , m_values(tensor.allocation_kokkos_view())
@@ -226,13 +225,12 @@ public:
     }
 };
 
-/*
 template <class ChainType, misc::Specialization<tensor::Tensor> TensorType>
-Cochain(ChainType, TensorType) -> Cochain<
-                                       ChainType,
-                                       typename TensorType::value_type,
-                                       typename TensorType::array_layout>;
-*/
+Cochain(ChainType, TensorType)
+        -> Cochain<
+                ChainType,
+                typename TensorType::value_type,
+                ddc::detail::mdspan_to_kokkos_layout_t<typename TensorType::array_layout>>;
 
 template <typename CochainType>
 class CochainIterator

--- a/include/similie/exterior/cochain.hpp
+++ b/include/similie/exterior/cochain.hpp
@@ -81,7 +81,7 @@ public:
                && "cochain constructor must get as much values as the chain contains simplices");
     }
 
-    template <tensor::TensorIndex Index, class OLayoutStridedPolicy>
+    template <tensor::TensorIndex Index>
         requires(misc::Specialization<Index, tensor::TensorAntisymmetricIndex>
                  || tensor::TensorNatIndex<Index>)
     KOKKOS_FUNCTION constexpr explicit Cochain(
@@ -89,11 +89,10 @@ public:
             tensor::Tensor<
                     element_type,
                     ddc::DiscreteDomain<Index>,
-                    OLayoutStridedPolicy,
+                    ddc::detail::kokkos_to_mdspan_layout_t<LayoutStridedPolicy>,
                     memory_space> tensor) noexcept
         : m_chain(std::move(chain))
-        // , m_values(tensor.allocation_kokkos_view())
-        , m_values("", 1)
+        , m_values(tensor.allocation_kokkos_view())
     {
         assert(m_values.size() == chain.size()
                && "cochain constructor must get as much values as the chain contains simplices");
@@ -230,7 +229,7 @@ Cochain(ChainType, TensorType)
         -> Cochain<
                 ChainType,
                 typename TensorType::value_type,
-                ddc::detail::mdspan_to_kokkos_layout_t<typename TensorType::array_layout>>;
+                ddc::detail::mdspan_to_kokkos_layout_t<typename TensorType::layout_type>>;
 
 template <typename CochainType>
 class CochainIterator

--- a/include/similie/exterior/cochain.hpp
+++ b/include/similie/exterior/cochain.hpp
@@ -73,7 +73,9 @@ public:
                && "cochain constructor must get as much values as the chain contains simplices");
     }
 
-    KOKKOS_FUNCTION constexpr explicit Cochain(chain_type& chain, values_type& values) noexcept
+    KOKKOS_FUNCTION constexpr explicit Cochain(
+            chain_type const& chain,
+            values_type const& values) noexcept
         : m_chain(std::move(chain))
         , m_values(std::move(values))
     {
@@ -85,7 +87,7 @@ public:
         requires(misc::Specialization<Index, tensor::TensorAntisymmetricIndex>
                  || tensor::TensorNatIndex<Index>)
     KOKKOS_FUNCTION constexpr explicit Cochain(
-            chain_type& chain,
+            chain_type const& chain,
             tensor::Tensor<
                     element_type,
                     ddc::DiscreteDomain<Index>,

--- a/include/similie/exterior/form.hpp
+++ b/include/similie/exterior/form.hpp
@@ -14,34 +14,34 @@ namespace exterior {
 
 namespace detail {
 
-template <class T, class ElementType, class ExecSpace>
+template <class T, class ElementType, class LayoutStridedPolicy>
 struct FormWrapper;
 
-template <misc::NotSpecialization<Chain> T, class ElementType, class ExecSpace>
-struct FormWrapper<T, ElementType, ExecSpace>
+template <misc::NotSpecialization<Chain> T, class ElementType, class LayoutStridedPolicy>
+struct FormWrapper<T, ElementType, LayoutStridedPolicy>
 {
     using type = Cosimplex<T, ElementType>;
 };
 
-template <misc::Specialization<Chain> T, class ElementType, class ExecSpace>
-struct FormWrapper<T, ElementType, ExecSpace>
+template <misc::Specialization<Chain> T, class ElementType, class LayoutStridedPolicy>
+struct FormWrapper<T, ElementType, LayoutStridedPolicy>
 {
-    using type = Cochain<T, ElementType, ExecSpace>;
+    using type = Cochain<T, ElementType, LayoutStridedPolicy>;
 };
 
 /*
-template <misc::NotSpecialization<Chain> Head, class ElementType>
-FormWrapper(Head, ElementType) -> FormWrapper<Head, ElementType, Kokkos::DefaultHostExecutionSpace>;
+template <misc::NotSpecialization<Chain> Head, class ElementType, class LayoutStridedPoliy >
+FormWrapper(Head, ElementType) -> FormWrapper<Head, ElementType, LayoutStridedPolicy, Kokkos::DefaultHostExecutionSpace>;
 
-template <misc::Specialization<Chain> Head, class ElementType, class ExecSpace>
-FormWrapper(Head, ElementType, Allocator) -> FormWrapper<Head, ElementType, ExecSpace>;
+template <misc::Specialization<Chain> Head, class ElementType, class LayoutStridedPolicy, class ExecSpace>
+FormWrapper(Head, ElementType, Allocator) -> FormWrapper<Head, ElementType, LayoutStridedPolicy, ExecSpace>;
 */
 
 } // namespace detail
 
 // Usage should be avoided because CTAD cannot go through it
-template <class T, class ElementType = double, class ExecSpace = Kokkos::DefaultHostExecutionSpace>
-using Form = typename detail::FormWrapper<T, ElementType, ExecSpace>::type;
+template <class T, class ElementType = double, class LayoutStridedPolicy = Kokkos::LayoutRight>
+using Form = typename detail::FormWrapper<T, ElementType, LayoutStridedPolicy>::type;
 
 } // namespace exterior
 

--- a/include/similie/exterior/hodge_star.hpp
+++ b/include/similie/exterior/hodge_star.hpp
@@ -61,7 +61,7 @@ HodgeStarType fill_hodge_star(
             ddc::DiscreteDomain<misc::convert_type_seq_to_t<
                     tensor::TensorLeviCivitaIndex,
                     ddc::type_seq_merge_t<tensor::primes<tensor::lower<Indices1>>, Indices2>>>,
-            Kokkos::layout_right,
+            Kokkos::LayoutRight,
             Kokkos::DefaultHostExecutionSpace::memory_space>
             levi_civita(levi_civita_alloc);
 
@@ -94,7 +94,7 @@ HodgeStarType fill_hodge_star(HodgeStarType hodge_star, MetricType metric)
     ddc::ChunkSpan<
             double,
             typename MetricType::non_indices_domain_t,
-            Kokkos::layout_right,
+            Kokkos::LayoutRight,
             Kokkos::DefaultHostExecutionSpace::memory_space>
             metric_det(metric_det_alloc);
     ddc::for_each( // TODO parallel_for_each (weird lock)
@@ -116,7 +116,7 @@ HodgeStarType fill_hodge_star(HodgeStarType hodge_star, MetricType metric)
             ddc::cartesian_prod_t<
                     typename MetricType::non_indices_domain_t,
                     tensor::metric_prod_domain_t<MetricIndex, Indices1, tensor::primes<Indices1>>>,
-            Kokkos::layout_right,
+            Kokkos::LayoutRight,
             Kokkos::DefaultHostExecutionSpace::memory_space>
             metric_prod(metric_prod_alloc);
 

--- a/include/similie/exterior/hodge_star.hpp
+++ b/include/similie/exterior/hodge_star.hpp
@@ -61,7 +61,7 @@ HodgeStarType fill_hodge_star(
             ddc::DiscreteDomain<misc::convert_type_seq_to_t<
                     tensor::TensorLeviCivitaIndex,
                     ddc::type_seq_merge_t<tensor::primes<tensor::lower<Indices1>>, Indices2>>>,
-            Kokkos::LayoutRight,
+            Kokkos::layout_right,
             Kokkos::DefaultHostExecutionSpace::memory_space>
             levi_civita(levi_civita_alloc);
 
@@ -94,7 +94,7 @@ HodgeStarType fill_hodge_star(HodgeStarType hodge_star, MetricType metric)
     ddc::ChunkSpan<
             double,
             typename MetricType::non_indices_domain_t,
-            Kokkos::LayoutRight,
+            Kokkos::layout_right,
             Kokkos::DefaultHostExecutionSpace::memory_space>
             metric_det(metric_det_alloc);
     ddc::for_each( // TODO parallel_for_each (weird lock)
@@ -116,7 +116,7 @@ HodgeStarType fill_hodge_star(HodgeStarType hodge_star, MetricType metric)
             ddc::cartesian_prod_t<
                     typename MetricType::non_indices_domain_t,
                     tensor::metric_prod_domain_t<MetricIndex, Indices1, tensor::primes<Indices1>>>,
-            Kokkos::LayoutRight,
+            Kokkos::layout_right,
             Kokkos::DefaultHostExecutionSpace::memory_space>
             metric_prod(metric_prod_alloc);
 

--- a/include/similie/exterior/local_chain.hpp
+++ b/include/similie/exterior/local_chain.hpp
@@ -75,8 +75,10 @@ public:
         ((m_vects(i++) = misc::filled_struct<discrete_vector_type>() + simplex.discrete_vector()),
          ...);
         assert(check() == 0 && "there are duplicate simplices in the chain");
-        assert(misc::are_all_equal(simplex.discrete_element()...)
-               && "LocalChain must contain simplices with same origin (if not, use Chain)");
+        if constexpr (sizeof...(T) > 1) {
+            assert(misc::are_all_equal(simplex.discrete_element()...)
+                   && "LocalChain must contain simplices with same origin (if not, use Chain)");
+        }
         assert((!simplex.negative() && ...)
                && "negative simplices are not supported in LocalChain");
     }
@@ -112,6 +114,7 @@ public:
     }
 
     template <misc::Specialization<ddc::DiscreteVector>... T>
+        requires(sizeof...(T) >= 1)
     KOKKOS_FUNCTION constexpr explicit LocalChain(vects_type allocation, T... vect) noexcept
         : m_vects(std::move(allocation))
         , m_size(sizeof...(T))

--- a/include/similie/exterior/local_chain.hpp
+++ b/include/similie/exterior/local_chain.hpp
@@ -18,10 +18,15 @@ namespace exterior {
 
 namespace detail {
 
-template <class SimplexType, class MemorySpace>
+template <
+        class SimplexType,
+        class LayoutStridedPolicy1,
+        class LayoutStridedPolicy2,
+        class MemorySpace>
 Kokkos::View<typename SimplexType::discrete_vector_type*, MemorySpace> extract_vects(
-        Kokkos::View<typename SimplexType::discrete_vector_type*, MemorySpace> vects,
-        Kokkos::View<SimplexType*, MemorySpace> simplices)
+        Kokkos::View<typename SimplexType::discrete_vector_type*, LayoutStridedPolicy1, MemorySpace>
+                vects,
+        Kokkos::View<SimplexType*, LayoutStridedPolicy2, MemorySpace> simplices)
 {
     for (auto i = Kokkos::Experimental::begin(simplices); i < Kokkos::Experimental::end(simplices);
          ++i) {
@@ -34,7 +39,10 @@ Kokkos::View<typename SimplexType::discrete_vector_type*, MemorySpace> extract_v
 
 
 /// LocalChain class
-template <class SimplexType, class ExecSpace = Kokkos::DefaultHostExecutionSpace>
+template <
+        class SimplexType,
+        class LayoutStridedPolicy = Kokkos::LayoutRight,
+        class ExecSpace = Kokkos::DefaultHostExecutionSpace>
 class LocalChain
 {
 public:
@@ -42,10 +50,10 @@ public:
     using memory_space = typename ExecSpace::memory_space;
 
     using simplex_type = SimplexType;
-    using simplices_type = Kokkos::View<SimplexType*, memory_space>;
+    using simplices_type = Kokkos::View<SimplexType*, LayoutStridedPolicy, memory_space>;
     using discrete_element_type = typename simplex_type::discrete_element_type;
     using discrete_vector_type = typename simplex_type::discrete_vector_type;
-    using vects_type = Kokkos::View<discrete_vector_type*, memory_space>;
+    using vects_type = Kokkos::View<discrete_vector_type*, LayoutStridedPolicy, memory_space>;
 
     using iterator_type = Kokkos::Experimental::Impl::RandomAccessIterator<vects_type>;
 
@@ -368,7 +376,7 @@ KOKKOS_FUNCTION constexpr LocalChain<Simplex<K, Tag...>> tangent_basis()
         ddc::detail::array(basis(i++)) = permutation;
     } while (std::prev_permutation(permutation.begin(), permutation.end()));
 
-    return LocalChain<Simplex<K, Tag...>>(basis);
+    return LocalChain<Simplex<K, Tag...>>(basis, basis.size());
 }
 
 namespace detail {

--- a/include/similie/exterior/local_chain.hpp
+++ b/include/similie/exterior/local_chain.hpp
@@ -90,11 +90,10 @@ public:
                && "negative simplices are not supported in LocalChain");
     }
 
-    KOKKOS_FUNCTION explicit LocalChain(
+    KOKKOS_FUNCTION constexpr explicit LocalChain(
             vects_type allocation,
             simplices_type simplices,
-            std::size_t
-                    size) noexcept // Can be constexpr with C++23 TODO is it not already the case now that simplices is a Kokkos::View ?
+            std::size_t size) noexcept
         : m_vects(std::move(allocation))
         , m_size(size)
     {

--- a/include/similie/exterior/local_chain.hpp
+++ b/include/similie/exterior/local_chain.hpp
@@ -20,13 +20,12 @@ namespace detail {
 
 template <class SimplexType, class MemorySpace>
 Kokkos::View<typename SimplexType::discrete_vector_type*, MemorySpace> extract_vects(
+        Kokkos::View<typename SimplexType::discrete_vector_type*, MemorySpace> vects,
         Kokkos::View<SimplexType*, MemorySpace> simplices)
 {
-    Kokkos::View<typename SimplexType::discrete_vector_type*, MemorySpace> vects(
-            simplices.extent(0));
     for (auto i = Kokkos::Experimental::begin(simplices); i < Kokkos::Experimental::end(simplices);
          ++i) {
-        vects[i] = i->discrete_vector();
+        vects(i) = i->discrete_vector();
     }
     return vects;
 }
@@ -53,7 +52,10 @@ public:
 private:
     static constexpr bool s_is_local = true;
     static constexpr std::size_t s_k = simplex_type::dimension();
+    // TODO m_elem ?
     vects_type m_vects;
+    std::size_t
+            m_size; // Effective size, m_simplices elements between m_size and m_simplices.size() are undefined
 
 public:
     KOKKOS_DEFAULTED_FUNCTION constexpr LocalChain() = default;
@@ -65,12 +67,13 @@ public:
     // TODO Reorganize discrete vectors in all constructors ?
 
     template <misc::NotSpecialization<ddc::DiscreteVector>... T>
-        requires misc::are_all_same<T...>
-    KOKKOS_FUNCTION constexpr explicit LocalChain(T... simplex) noexcept
-        : m_vects("local_chain_vects", sizeof...(T))
+    KOKKOS_FUNCTION constexpr explicit LocalChain(vects_type allocation, T... simplex) noexcept
+        : m_vects(std::move(allocation))
+        , m_size(sizeof...(T))
     {
-        int i = 0;
-        ((m_vects(i++) = simplex.discrete_vector()), ...);
+        std::size_t i = 0;
+        ((m_vects(i++) = misc::filled_struct<discrete_vector_type>() + simplex.discrete_vector()),
+         ...);
         assert(check() == 0 && "there are duplicate simplices in the chain");
         assert(misc::are_all_equal(simplex.discrete_element()...)
                && "LocalChain must contain simplices with same origin (if not, use Chain)");
@@ -79,37 +82,48 @@ public:
     }
 
     KOKKOS_FUNCTION explicit LocalChain(
-            simplices_type simplices) noexcept // Can be constexpr with C++23
-        : m_vects(detail::extract_vects(simplices))
+            vects_type allocation,
+            simplices_type simplices,
+            std::size_t
+                    size) noexcept // Can be constexpr with C++23 TODO is it not already the case now that simplices is a Kokkos::View ?
+        : m_vects(std::move(allocation))
+        , m_size(size)
     {
-        assert(check() == 0 && "there are duplicate simplices in the chain");
-        std::function<bool()> check_common_elem = [&]() {
-            Kokkos::View<discrete_element_type*, memory_space> elems(simplices.size());
-            for (auto i = Kokkos::Experimental::begin(simplices);
-                 i < Kokkos::Experimental::end(simplices);
-                 ++i) {
-                elems[Kokkos::Experimental::distance(Kokkos::Experimental::begin(simplices), i)]
-                        = i->discrete_element();
-            }
-            return misc::are_all_equal(elems);
-        };
-        assert(check_common_elem()
+        detail::extract_vects(m_vects, simplices)
+                assert(check() == 0 && "there are duplicate simplices in the chain");
+        assert((KOKKOS_LAMBDA() {
+                   Kokkos::View<discrete_element_type*, memory_space> elems(simplices.size());
+                   for (auto i = Kokkos::Experimental::begin(simplices);
+                        i < Kokkos::Experimental::end(simplices);
+                        ++i) {
+                       elems[Kokkos::Experimental::
+                                     distance(Kokkos::Experimental::begin(simplices), i)]
+                               = i->discrete_element();
+                   }
+                   return misc::are_all_equal(elems);
+               })()
                && "LocalChain must contain simplices with same origin (if not, use Chain)");
-        assert(std::
-                       all_of(Kokkos::Experimental::begin(simplices),
-                              Kokkos::Experimental::end(simplices),
-                              [&](const std::size_t i) { return !simplices[i].negative(); })
+        // TODO Kokkosify
+        assert(std::all_of(
+                       Kokkos::Experimental::begin(simplices),
+                       Kokkos::Experimental::end(simplices),
+                       KOKKOS_LAMBDA(const std::size_t i) { return !simplices[i].negative(); })
                && "LocalChain must contain simplices with same origin (if not, use Chain)");
     }
 
     template <misc::Specialization<ddc::DiscreteVector>... T>
-    KOKKOS_FUNCTION constexpr explicit LocalChain(T... vect) noexcept
-        : m_vects {(misc::filled_struct<discrete_vector_type>() + vect)...}
+    KOKKOS_FUNCTION constexpr explicit LocalChain(vects_type allocation, T... vect) noexcept
+        : m_vects(std::move(allocation))
+        , m_size(sizeof...(T))
     {
+        std::size_t i = 0;
+        ((m_vects(i++) = misc::filled_struct<discrete_vector_type>() + vect), ...);
         assert(check() == 0 && "there are duplicate simplices in the chain");
     }
 
-    KOKKOS_FUNCTION constexpr explicit LocalChain(vects_type vects) noexcept : m_vects(vects)
+    KOKKOS_FUNCTION constexpr explicit LocalChain(vects_type allocation, std::size_t size) noexcept
+        : m_vects(std::move(allocation))
+        , m_size(size)
     {
         assert(check() == 0 && "there are duplicate simplices in the chain");
     }
@@ -130,12 +144,27 @@ public:
         return s_k;
     }
 
+    KOKKOS_FUNCTION simplices_type& allocation() noexcept
+    {
+        return m_vects;
+    }
+
     KOKKOS_FUNCTION std::size_t size() noexcept
+    {
+        return m_size;
+    }
+
+    KOKKOS_FUNCTION std::size_t size() const noexcept
+    {
+        return m_size;
+    }
+
+    KOKKOS_FUNCTION std::size_t allocation_size() noexcept
     {
         return m_vects.size();
     }
 
-    KOKKOS_FUNCTION std::size_t size() const noexcept
+    KOKKOS_FUNCTION std::size_t allocation_size() const noexcept
     {
         return m_vects.size();
     }
@@ -143,6 +172,16 @@ public:
     static KOKKOS_FUNCTION constexpr bool negative()
     {
         return false;
+    }
+
+    void resize()
+    {
+        Kokkos::resize(m_vects, size());
+    }
+
+    void resize(std::size_t size)
+    {
+        Kokkos::resize(m_vects, size);
     }
 
     KOKKOS_FUNCTION int check()
@@ -169,12 +208,12 @@ public:
 
     KOKKOS_FUNCTION auto end()
     {
-        return Kokkos::Experimental::end(m_vects);
+        return Kokkos::Experimental::begin(m_vects) + size();
     }
 
     KOKKOS_FUNCTION auto end() const
     {
-        return Kokkos::Experimental::end(m_vects);
+        return Kokkos::Experimental::begin(m_vects) + size();
     }
 
     KOKKOS_FUNCTION auto cbegin() const
@@ -184,81 +223,108 @@ public:
 
     KOKKOS_FUNCTION auto cend() const
     {
-        return Kokkos::Experimental::end(m_vects);
+        return Kokkos::Experimental::begin(m_vects) + size();
     }
 
     KOKKOS_FUNCTION simplex_type operator[](std::size_t i) noexcept
     {
+        assert(i < size());
         return simplex_type(misc::filled_struct<discrete_element_type>(), m_vects[i]);
     }
 
     KOKKOS_FUNCTION simplex_type const operator[](std::size_t i) const noexcept
     {
+        assert(i < size());
         return simplex_type(misc::filled_struct<discrete_element_type>(), m_vects[i]);
     }
 
-    // TODO operator +=
-    KOKKOS_FUNCTION void push_back(const discrete_vector_type& vect)
+    KOKKOS_FUNCTION LocalChain<simplex_type>& operator++()
     {
-        Kokkos::resize(m_vects, m_vects.size() + 1);
-        m_vects(m_vects.size() - 1) = vect;
+        assert(size() < allocation_size());
+        m_size++;
+        return *this;
     }
 
-    KOKKOS_FUNCTION void push_back(const simplex_type& simplex)
+    KOKKOS_FUNCTION LocalChain<simplex_type>& operator+=(const std::size_t n)
     {
-        Kokkos::resize(m_vects, m_vects.size() + 1);
-        m_vects(m_vects.size() - 1) = simplex.discrete_vector();
+        assert(size() + n <= allocation_size());
+        m_size += n;
+        return *this;
     }
 
-    KOKKOS_FUNCTION void push_back(const vects_type& vects)
+    KOKKOS_FUNCTION LocalChain<simplex_type>& operator+=(const discrete_vector_type& vect)
     {
-        std::size_t old_size = m_vects.size();
-        Kokkos::resize(m_vects, old_size + vects.size());
-        for (auto i = Kokkos::Experimental::begin(vects); i < Kokkos::Experimental::end(vects);
-             ++i) {
-            m_vects(old_size
-                    + Kokkos::Experimental::distance(Kokkos::Experimental::begin(vects), i))
-                    = *i;
+        assert(size() < allocation_size());
+        m_vects(m_size) = vect;
+        m_size++;
+        return *this;
+    }
+
+    KOKKOS_FUNCTION LocalChain<simplex_type>& operator+=(const simplex_type& simplex)
+    {
+        assert(size() < allocation_size());
+        m_vects(m_size) = simplex.discrete_vector();
+        m_size++;
+        return *this;
+    }
+
+    KOKKOS_FUNCTION LocalChain<simplex_type>& operator+=(const vects_type& vects_to_add)
+    {
+        assert(size() + vects_to_add.size() <= allocation_size());
+        for (auto i = vects_to_add.begin(); i < vects_to_add.end(); ++i) {
+            m_vects(m_size + Kokkos::Experimental::distance(vects_to_add.begin(), i)) = *i;
         }
+        m_size += vects_to_add.size();
+        return *this;
     }
 
-    KOKKOS_FUNCTION void push_back(const LocalChain<simplex_type>& simplices_to_add)
+    KOKKOS_FUNCTION LocalChain<simplex_type>& operator+=(
+            const LocalChain<simplex_type>& simplices_to_add)
     {
-        std::size_t old_size = m_vects.size();
-        Kokkos::resize(m_vects, old_size + simplices_to_add.size());
+        assert(size() + simplices_to_add.size() <= allocation_size());
         for (auto i = simplices_to_add.begin(); i < simplices_to_add.end(); ++i) {
-            m_vects(old_size + Kokkos::Experimental::distance(simplices_to_add.begin(), i)) = *i;
+            m_vects(m_size + Kokkos::Experimental::distance(simplices_to_add.begin(), i)) = *i;
         }
+        m_size += simplices_to_add.size();
+        return *this;
     }
-
-    LocalChain<simplex_type> operator-() = delete;
 
     KOKKOS_FUNCTION LocalChain<simplex_type> operator+(simplex_type simplex)
     {
         LocalChain<simplex_type> local_chain = *this;
-        local_chain.push_back(simplex);
+        local_chain += simplex;
         return local_chain;
     }
 
     KOKKOS_FUNCTION LocalChain<simplex_type> operator+(LocalChain<simplex_type> simplices_to_add)
     {
         LocalChain<simplex_type> local_chain = *this;
-        local_chain.push_back(simplices_to_add);
+        local_chain += simplices_to_add;
         return local_chain;
     }
+
+    LocalChain<simplex_type> operator-() = delete;
 
     LocalChain<simplex_type> operator-(LocalChain<simplex_type>) = delete;
 
     template <class T>
-    KOKKOS_FUNCTION auto operator*(T t)
+    KOKKOS_FUNCTION LocalChain<simplex_type>& operator*=(T t)
     {
         if (t == 1) {
-            return *this;
         } else if (t == -1) {
             assert(false && "negative simplices are unsupported in LocalChain");
         } else {
             assert(false && "chain must be multiplied  by 1 or -1");
         }
+        return *this;
+    }
+
+    template <class T>
+    KOKKOS_FUNCTION auto operator*(T t)
+    {
+        Chain<simplex_type> chain = *this;
+        chain *= t;
+        return chain;
     }
 
     KOKKOS_FUNCTION bool operator==(LocalChain<simplex_type> simplices)
@@ -272,9 +338,17 @@ public:
     }
 };
 
-template <misc::NotSpecialization<ddc::DiscreteVector>... T>
-LocalChain(T...) -> LocalChain<ddc::type_seq_element_t<0, ddc::detail::TypeSeq<T...>>>;
+template <class Head, misc::NotSpecialization<ddc::DiscreteVector>... Tail>
+LocalChain(Head, Tail...) -> LocalChain<ddc::type_seq_element_t<0, ddc::detail::TypeSeq<Tail...>>>;
 
+template <class Head, misc::Specialization<ddc::DiscreteVector>... Tail>
+LocalChain(Head, Tail...) -> LocalChain<decltype(Simplex(
+                                  misc::convert_type_seq_to_t<
+                                          ddc::DiscreteElement,
+                                          ddc::to_type_seq_t<typename Head::value_type>>(),
+                                  ddc::type_seq_element_t<0, ddc::detail::TypeSeq<Tail...>>()))>;
+
+// TODO Kokkosify
 template <std::size_t K, misc::NotSpecialization<ddc::DiscreteDomain>... Tag>
 KOKKOS_FUNCTION constexpr LocalChain<Simplex<K, Tag...>> tangent_basis()
 {

--- a/include/similie/exterior/local_chain.hpp
+++ b/include/similie/exterior/local_chain.hpp
@@ -197,6 +197,7 @@ public:
         return simplex_type(misc::filled_struct<discrete_element_type>(), m_vects[i]);
     }
 
+    // TODO operator +=
     KOKKOS_FUNCTION void push_back(const discrete_vector_type& vect)
     {
         Kokkos::resize(m_vects, m_vects.size() + 1);

--- a/include/similie/exterior/simplex.hpp
+++ b/include/similie/exterior/simplex.hpp
@@ -216,6 +216,22 @@ Simplex(ddc::DiscreteElement<Tag...>,
         ddc::DiscreteVector<T...>,
         bool) -> Simplex<sizeof...(T), Tag...>;
 
+namespace detail {
+
+template <std::size_t K, class Dom>
+struct SimplexForDomain;
+
+template <std::size_t K, class... Tag>
+struct SimplexForDomain<K, ddc::DiscreteDomain<Tag...>>
+{
+    using type = Simplex<K, Tag...>;
+};
+
+} // namespace detail
+
+template <std::size_t K, class Dom>
+using simplex_for_domain_t = detail::SimplexForDomain<K, Dom>::type;
+
 template <std::size_t K, class... Tag>
 std::ostream& operator<<(std::ostream& out, Simplex<K, Tag...> const& simplex)
 {

--- a/include/similie/exterior/simplex.hpp
+++ b/include/similie/exterior/simplex.hpp
@@ -118,7 +118,7 @@ public:
     template <misc::Specialization<ddc::DiscreteVector> T>
     KOKKOS_FUNCTION constexpr explicit Simplex(
             discrete_element_type elem,
-            T vect,
+            T vect = ddc::DiscreteVector<> {},
             bool negative = false) noexcept
         : base_type(detail::Reorient<Tag...>::run_elem(elem, add_null_dimensions(vect)))
         , m_vect(detail::Reorient<Tag...>::run_vect(elem, add_null_dimensions(vect)))
@@ -128,11 +128,11 @@ public:
                && "simplex vector must contain only -1, 0 or 1");
     }
 
-    template <misc::Specialization<ddc::DiscreteVector> T>
+    template <misc::Specialization<ddc::DiscreteVector> T = ddc::DiscreteVector<>>
     KOKKOS_FUNCTION constexpr explicit Simplex(
             std::integral_constant<std::size_t, K>,
             discrete_element_type elem,
-            T vect,
+            T vect = ddc::DiscreteVector<> {},
             bool negative = false) noexcept
         : base_type(detail::Reorient<Tag...>::run_elem(elem, add_null_dimensions(vect)))
         , m_vect(detail::Reorient<Tag...>::run_vect(elem, add_null_dimensions(vect)))

--- a/tests/exterior/exterior.cpp
+++ b/tests/exterior/exterior.cpp
@@ -412,14 +412,21 @@ TEST(Boundary, Chain)
                                           ddc::DiscreteVector<DDimX> {-1})));
 }
 
-/*
 TEST(Boundary, PoincarreLemma2)
 {
     sil::exterior::Simplex simplex = sil::exterior::
             Simplex(ddc::DiscreteElement<DDimT, DDimX, DDimY, DDimZ> {0, 0, 0, 0},
                     ddc::DiscreteVector<DDimX, DDimY> {1, 1});
-    sil::exterior::Chain boundary_chain = sil::exterior::boundary(simplex);
-    sil::exterior::Chain boundary_chain2 = sil::exterior::boundary(boundary_chain);
+    sil::exterior::Chain boundary_chain = sil::exterior::boundary(
+            Kokkos::View<
+                    sil::exterior::Simplex<1, DDimT, DDimX, DDimY, DDimZ>*,
+                    Kokkos::HostSpace>("", 4),
+            simplex);
+    sil::exterior::Chain boundary_chain2 = sil::exterior::boundary(
+            Kokkos::View<
+                    sil::exterior::Simplex<0, DDimT, DDimX, DDimY, DDimZ>*,
+                    Kokkos::HostSpace>("", 8),
+            boundary_chain);
     auto empty_chain
             = sil::exterior::Chain<sil::exterior::Simplex<0, DDimT, DDimX, DDimY, DDimZ>> {};
     EXPECT_TRUE(boundary_chain2 == empty_chain);
@@ -430,8 +437,16 @@ TEST(Boundary, PoincarreLemma3)
     sil::exterior::Simplex simplex = sil::exterior::
             Simplex(ddc::DiscreteElement<DDimT, DDimX, DDimY, DDimZ> {0, 0, 0, 0},
                     ddc::DiscreteVector<DDimX, DDimY, DDimZ> {1, 1, 1});
-    sil::exterior::Chain boundary_chain = sil::exterior::boundary(simplex);
-    sil::exterior::Chain boundary_chain2 = sil::exterior::boundary(boundary_chain);
+    sil::exterior::Chain boundary_chain = sil::exterior::boundary(
+            Kokkos::View<
+                    sil::exterior::Simplex<2, DDimT, DDimX, DDimY, DDimZ>*,
+                    Kokkos::HostSpace>("", 6),
+            simplex);
+    sil::exterior::Chain boundary_chain2 = sil::exterior::boundary(
+            Kokkos::View<
+                    sil::exterior::Simplex<1, DDimT, DDimX, DDimY, DDimZ>*,
+                    Kokkos::HostSpace>("", 24),
+            boundary_chain);
     auto empty_chain
             = sil::exterior::Chain<sil::exterior::Simplex<1, DDimT, DDimX, DDimY, DDimZ>> {};
     EXPECT_TRUE(boundary_chain2 == empty_chain);
@@ -442,8 +457,16 @@ TEST(Boundary, PoincarreLemma4)
     sil::exterior::Simplex simplex = sil::exterior::
             Simplex(ddc::DiscreteElement<DDimT, DDimX, DDimY, DDimZ> {0, 0, 0, 0},
                     ddc::DiscreteVector<DDimT, DDimX, DDimY, DDimZ> {1, 1, 1, 1});
-    sil::exterior::Chain boundary_chain = sil::exterior::boundary(simplex);
-    sil::exterior::Chain boundary_chain2 = sil::exterior::boundary(boundary_chain);
+    sil::exterior::Chain boundary_chain = sil::exterior::boundary(
+            Kokkos::View<
+                    sil::exterior::Simplex<3, DDimT, DDimX, DDimY, DDimZ>*,
+                    Kokkos::HostSpace>("", 8),
+            simplex);
+    sil::exterior::Chain boundary_chain2 = sil::exterior::boundary(
+            Kokkos::View<
+                    sil::exterior::Simplex<2, DDimT, DDimX, DDimY, DDimZ>*,
+                    Kokkos::HostSpace>("", 64),
+            boundary_chain);
     auto empty_chain
             = sil::exterior::Chain<sil::exterior::Simplex<2, DDimT, DDimX, DDimY, DDimZ>> {};
     EXPECT_TRUE(boundary_chain2 == empty_chain);
@@ -451,15 +474,19 @@ TEST(Boundary, PoincarreLemma4)
 
 TEST(Form, Alias)
 {
-    sil::exterior::Chain chain(
-            sil::exterior::
-                    Simplex(ddc::DiscreteElement<DDimT, DDimX, DDimY, DDimZ> {0, 1, 0, 0},
-                            ddc::DiscreteVector<DDimX, DDimY> {1, 1}));
+    sil::exterior::Chain
+            chain(Kokkos::View<
+                          sil::exterior::Simplex<2, DDimT, DDimX, DDimY, DDimZ>*,
+                          Kokkos::HostSpace>("", 1),
+                  sil::exterior::
+                          Simplex(ddc::DiscreteElement<DDimT, DDimX, DDimY, DDimZ> {0, 1, 0, 0},
+                                  ddc::DiscreteVector<DDimX, DDimY> {1, 1}));
     // Unfortunately CTAD cannot deduce template arguments
     sil::exterior::Form<typename decltype(chain)::simplex_type> cosimplex(chain[0], 0.);
     sil::exterior::Form<decltype(chain)> cochain(chain, 0.);
 }
 
+/*
 TEST(Cochain, Test)
 {
     sil::exterior::Chain

--- a/tests/exterior/exterior.cpp
+++ b/tests/exterior/exterior.cpp
@@ -55,7 +55,7 @@ TEST(Chain, Optimization)
     chain_alloc2(0) = sil::exterior::
             Simplex(ddc::DiscreteElement<DDimT, DDimX, DDimY, DDimZ> {0, 0, 0, 1},
                     ddc::DiscreteVector<DDimX, DDimY> {1, 1});
-    sil::exterior::Chain chain2(chain_alloc2);
+    sil::exterior::Chain chain2(chain_alloc2, chain_alloc2.size());
     chain = chain
             + sil::exterior::
                     Simplex(ddc::DiscreteElement<DDimT, DDimX, DDimY, DDimZ> {0, 1, 1, 0},
@@ -88,17 +88,21 @@ TEST(Chain, Optimization)
     EXPECT_TRUE(chain == chain3);
 }
 
-/*
 TEST(Boundary, 1Simplex)
 {
     sil::exterior::Simplex
             simplex(ddc::DiscreteElement<DDimT, DDimX, DDimY, DDimZ> {0, 0, 0, 0},
                     ddc::DiscreteVector<DDimX> {1});
-    sil::exterior::Chain chain = sil::exterior::boundary(simplex);
+    Kokkos::View<sil::exterior::Simplex<0, DDimT, DDimX, DDimY, DDimZ>*, Kokkos::HostSpace>
+            chain_alloc("", 2);
+    sil::exterior::Chain chain = sil::exterior::boundary(chain_alloc, simplex);
+    Kokkos::View<sil::exterior::Simplex<0, DDimT, DDimX, DDimY, DDimZ>*, Kokkos::HostSpace>
+            chain_alloc2("", 2);
     EXPECT_TRUE(
             chain
             == sil::exterior::
-                    Chain(sil::exterior::
+                    Chain(chain_alloc2,
+                          sil::exterior::
                                   Simplex(ddc::DiscreteElement<
                                                   DDimT,
                                                   DDimX,
@@ -115,6 +119,7 @@ TEST(Boundary, 1Simplex)
                                           ddc::DiscreteVector<> {})));
 }
 
+/*
 TEST(Boundary, 2Simplex)
 {
     sil::exterior::Simplex

--- a/tests/exterior/exterior.cpp
+++ b/tests/exterior/exterior.cpp
@@ -46,6 +46,7 @@ TEST(Chain, Optimization)
     sil::exterior::Chain chain = sil::exterior::
             Chain(Kokkos::View<
                           sil::exterior::Simplex<2, DDimT, DDimX, DDimY, DDimZ>*,
+                          Kokkos::LayoutRight,
                           Kokkos::HostSpace>("", 5),
                   sil::exterior::
                           Simplex(ddc::DiscreteElement<DDimT, DDimX, DDimY, DDimZ> {0, 0, 0, 0},
@@ -53,6 +54,7 @@ TEST(Chain, Optimization)
     sil::exterior::Chain
             chain2(Kokkos::View<
                            sil::exterior::Simplex<2, DDimT, DDimX, DDimY, DDimZ>*,
+                           Kokkos::LayoutRight,
                            Kokkos::HostSpace>("", 1),
                    1);
     chain2[0] = sil::exterior::
@@ -76,6 +78,7 @@ TEST(Chain, Optimization)
             == sil::exterior::
                     Chain(Kokkos::View<
                                   sil::exterior::Simplex<2, DDimT, DDimX, DDimY, DDimZ>*,
+                                  Kokkos::LayoutRight,
                                   Kokkos::HostSpace>("", 3),
                           sil::exterior::
                                   Simplex(ddc::DiscreteElement<
@@ -111,6 +114,7 @@ TEST(Boundary, 1Simplex)
     sil::exterior::Chain chain = sil::exterior::boundary(
             Kokkos::View<
                     sil::exterior::Simplex<0, DDimT, DDimX, DDimY, DDimZ>*,
+                    Kokkos::LayoutRight,
                     Kokkos::HostSpace>("", 2),
             simplex);
     EXPECT_TRUE(
@@ -118,6 +122,7 @@ TEST(Boundary, 1Simplex)
             == sil::exterior::
                     Chain(Kokkos::View<
                                   sil::exterior::Simplex<0, DDimT, DDimX, DDimY, DDimZ>*,
+                                  Kokkos::LayoutRight,
                                   Kokkos::HostSpace>("", 2),
                           sil::exterior::
                                   Simplex(ddc::DiscreteElement<
@@ -144,6 +149,7 @@ TEST(Boundary, 2Simplex)
     sil::exterior::Chain chain = sil::exterior::boundary(
             Kokkos::View<
                     sil::exterior::Simplex<1, DDimT, DDimX, DDimY, DDimZ>*,
+                    Kokkos::LayoutRight,
                     Kokkos::HostSpace>("", 4),
             simplex);
     EXPECT_TRUE(
@@ -151,6 +157,7 @@ TEST(Boundary, 2Simplex)
             == sil::exterior::
                     Chain(Kokkos::View<
                                   sil::exterior::Simplex<1, DDimT, DDimX, DDimY, DDimZ>*,
+                                  Kokkos::LayoutRight,
                                   Kokkos::HostSpace>("", 4),
                           sil::exterior::
                                   Simplex(ddc::DiscreteElement<
@@ -187,6 +194,7 @@ TEST(Boundary, 2Simplex)
     sil::exterior::Chain chain2 = sil::exterior::boundary(
             Kokkos::View<
                     sil::exterior::Simplex<1, DDimT, DDimX, DDimY, DDimZ>*,
+                    Kokkos::LayoutRight,
                     Kokkos::HostSpace>("", 4),
             simplex2);
     EXPECT_TRUE(
@@ -194,6 +202,7 @@ TEST(Boundary, 2Simplex)
             == sil::exterior::
                     Chain(Kokkos::View<
                                   sil::exterior::Simplex<1, DDimT, DDimX, DDimY, DDimZ>*,
+                                  Kokkos::LayoutRight,
                                   Kokkos::HostSpace>("", 4),
                           sil::exterior::
                                   Simplex(ddc::DiscreteElement<
@@ -233,6 +242,7 @@ TEST(Boundary, 3Simplex)
     sil::exterior::Chain chain = sil::exterior::boundary(
             Kokkos::View<
                     sil::exterior::Simplex<2, DDimT, DDimX, DDimY, DDimZ>*,
+                    Kokkos::LayoutRight,
                     Kokkos::HostSpace>("", 6),
             simplex);
     EXPECT_TRUE(
@@ -240,6 +250,7 @@ TEST(Boundary, 3Simplex)
             == sil::exterior::
                     Chain(Kokkos::View<
                                   sil::exterior::Simplex<2, DDimT, DDimX, DDimY, DDimZ>*,
+                                  Kokkos::LayoutRight,
                                   Kokkos::HostSpace>("", 6),
                           sil::exterior::
                                   Simplex(ddc::DiscreteElement<
@@ -292,6 +303,7 @@ TEST(Boundary, 3Simplex)
     sil::exterior::Chain chain2 = sil::exterior::boundary(
             Kokkos::View<
                     sil::exterior::Simplex<2, DDimT, DDimX, DDimY, DDimZ>*,
+                    Kokkos::LayoutRight,
                     Kokkos::HostSpace>("", 6),
             simplex2);
     EXPECT_TRUE(
@@ -299,6 +311,7 @@ TEST(Boundary, 3Simplex)
             == sil::exterior::
                     Chain(Kokkos::View<
                                   sil::exterior::Simplex<2, DDimT, DDimX, DDimY, DDimZ>*,
+                                  Kokkos::LayoutRight,
                                   Kokkos::HostSpace>("", 6),
                           sil::exterior::
                                   Simplex(ddc::DiscreteElement<
@@ -352,6 +365,7 @@ TEST(Boundary, Chain)
     sil::exterior::Chain chain = sil::exterior::
             Chain(Kokkos::View<
                           sil::exterior::Simplex<2, DDimT, DDimX, DDimY, DDimZ>*,
+                          Kokkos::LayoutRight,
                           Kokkos::HostSpace>("", 2),
                   sil::exterior::
                           Simplex(ddc::DiscreteElement<DDimT, DDimX, DDimY, DDimZ> {0, 0, 0, 0},
@@ -362,6 +376,7 @@ TEST(Boundary, Chain)
     sil::exterior::Chain boundary_chain = sil::exterior::boundary(
             Kokkos::View<
                     sil::exterior::Simplex<1, DDimT, DDimX, DDimY, DDimZ>*,
+                    Kokkos::LayoutRight,
                     Kokkos::HostSpace>("", 8),
             chain);
     EXPECT_TRUE(
@@ -369,6 +384,7 @@ TEST(Boundary, Chain)
             == sil::exterior::
                     Chain(Kokkos::View<
                                   sil::exterior::Simplex<1, DDimT, DDimX, DDimY, DDimZ>*,
+                                  Kokkos::LayoutRight,
                                   Kokkos::HostSpace>("", 8),
                           sil::exterior::
                                   Simplex(ddc::DiscreteElement<
@@ -422,11 +438,13 @@ TEST(Boundary, PoincarreLemma2)
     sil::exterior::Chain boundary_chain = sil::exterior::boundary(
             Kokkos::View<
                     sil::exterior::Simplex<1, DDimT, DDimX, DDimY, DDimZ>*,
+                    Kokkos::LayoutRight,
                     Kokkos::HostSpace>("", 4),
             simplex);
     sil::exterior::Chain boundary_chain2 = sil::exterior::boundary(
             Kokkos::View<
                     sil::exterior::Simplex<0, DDimT, DDimX, DDimY, DDimZ>*,
+                    Kokkos::LayoutRight,
                     Kokkos::HostSpace>("", 8),
             boundary_chain);
     auto empty_chain
@@ -442,11 +460,13 @@ TEST(Boundary, PoincarreLemma3)
     sil::exterior::Chain boundary_chain = sil::exterior::boundary(
             Kokkos::View<
                     sil::exterior::Simplex<2, DDimT, DDimX, DDimY, DDimZ>*,
+                    Kokkos::LayoutRight,
                     Kokkos::HostSpace>("", 6),
             simplex);
     sil::exterior::Chain boundary_chain2 = sil::exterior::boundary(
             Kokkos::View<
                     sil::exterior::Simplex<1, DDimT, DDimX, DDimY, DDimZ>*,
+                    Kokkos::LayoutRight,
                     Kokkos::HostSpace>("", 24),
             boundary_chain);
     auto empty_chain
@@ -462,11 +482,13 @@ TEST(Boundary, PoincarreLemma4)
     sil::exterior::Chain boundary_chain = sil::exterior::boundary(
             Kokkos::View<
                     sil::exterior::Simplex<3, DDimT, DDimX, DDimY, DDimZ>*,
+                    Kokkos::LayoutRight,
                     Kokkos::HostSpace>("", 8),
             simplex);
     sil::exterior::Chain boundary_chain2 = sil::exterior::boundary(
             Kokkos::View<
                     sil::exterior::Simplex<2, DDimT, DDimX, DDimY, DDimZ>*,
+                    Kokkos::LayoutRight,
                     Kokkos::HostSpace>("", 64),
             boundary_chain);
     auto empty_chain
@@ -479,6 +501,7 @@ TEST(Form, Alias)
     sil::exterior::Chain
             chain(Kokkos::View<
                           sil::exterior::Simplex<2, DDimT, DDimX, DDimY, DDimZ>*,
+                          Kokkos::LayoutRight,
                           Kokkos::HostSpace>("", 1),
                   sil::exterior::
                           Simplex(ddc::DiscreteElement<DDimT, DDimX, DDimY, DDimZ> {0, 1, 0, 0},
@@ -486,7 +509,9 @@ TEST(Form, Alias)
     // Unfortunately CTAD cannot deduce template arguments
     sil::exterior::Form<typename decltype(chain)::simplex_type> cosimplex(chain[0], 0.);
     sil::exterior::Form<decltype(chain)>
-            cochain(chain, Kokkos::View<double*, Kokkos::HostSpace>("", 1), 0.);
+            cochain(chain,
+                    Kokkos::View<double*, Kokkos::LayoutRight, Kokkos::HostSpace>("", 1),
+                    0.);
 }
 
 TEST(Cochain, Test)
@@ -494,6 +519,7 @@ TEST(Cochain, Test)
     sil::exterior::Chain
             chain(Kokkos::View<
                           sil::exterior::Simplex<2, DDimT, DDimX, DDimY, DDimZ>*,
+                          Kokkos::LayoutRight,
                           Kokkos::HostSpace>("", 3),
                   sil::exterior::
                           Simplex(ddc::DiscreteElement<DDimT, DDimX, DDimY, DDimZ> {0, 1, 0, 0},
@@ -506,7 +532,11 @@ TEST(Cochain, Test)
                                   ddc::DiscreteVector<DDimX, DDimY> {1, 1},
                                   true));
     sil::exterior::Cochain
-            cochain(chain, Kokkos::View<double*, Kokkos::HostSpace>("", 3), 0., 1., 2.);
+            cochain(chain,
+                    Kokkos::View<double*, Kokkos::LayoutRight, Kokkos::HostSpace>("", 3),
+                    0.,
+                    1.,
+                    2.);
     EXPECT_EQ(cochain.integrate(), -1.);
 }
 
@@ -518,11 +548,12 @@ TEST(Coboundary, Test)
     sil::exterior::Chain simplex_boundary = boundary(
             Kokkos::View<
                     sil::exterior::Simplex<1, DDimT, DDimX, DDimY, DDimZ>*,
+                    Kokkos::LayoutRight,
                     Kokkos::HostSpace>("", 4),
             simplex);
     sil::exterior::Cochain cochain_boundary(
             simplex_boundary,
-            Kokkos::View<double*, Kokkos::HostSpace>("", 4),
+            Kokkos::View<double*, Kokkos::LayoutRight, Kokkos::HostSpace>("", 4),
             5.,
             8.,
             3.,
@@ -537,6 +568,7 @@ TEST(LocalChain, Test)
     sil::exterior::LocalChain
             chain(Kokkos::View<
                           ddc::DiscreteVector<DDimT, DDimX, DDimY, DDimZ>*,
+                          Kokkos::LayoutRight,
                           Kokkos::HostSpace>("", 4),
                   sil::exterior::
                           Simplex(ddc::DiscreteElement<DDimT, DDimX, DDimY, DDimZ> {0, 0, 0, 0},
@@ -552,6 +584,7 @@ TEST(LocalChain, Test)
             + sil::exterior::LocalChain(
                     Kokkos::View<
                             ddc::DiscreteVector<DDimT, DDimX, DDimY, DDimZ>*,
+                            Kokkos::LayoutRight,
                             Kokkos::HostSpace>("", 1),
                     sil::exterior::
                             Simplex(ddc::DiscreteElement<DDimT, DDimX, DDimY, DDimZ> {0, 0, 0, 0},
@@ -561,6 +594,7 @@ TEST(LocalChain, Test)
             == sil::exterior::LocalChain(
                     Kokkos::View<
                             ddc::DiscreteVector<DDimT, DDimX, DDimY, DDimZ>*,
+                            Kokkos::LayoutRight,
                             Kokkos::HostSpace>("", 4),
                     sil::exterior::
                             Simplex(ddc::DiscreteElement<DDimT, DDimX, DDimY, DDimZ> {0, 0, 0, 0},
@@ -581,6 +615,7 @@ TEST(LocalCochain, Test)
     sil::exterior::LocalChain
             chain(Kokkos::View<
                           ddc::DiscreteVector<DDimT, DDimX, DDimY, DDimZ>*,
+                          Kokkos::LayoutRight,
                           Kokkos::HostSpace>("", 2),
                   sil::exterior::
                           Simplex(ddc::DiscreteElement<DDimT, DDimX, DDimY, DDimZ> {0, 0, 0, 0},
@@ -588,6 +623,10 @@ TEST(LocalCochain, Test)
                   sil::exterior::
                           Simplex(ddc::DiscreteElement<DDimT, DDimX, DDimY, DDimZ> {0, 0, 0, 0},
                                   ddc::DiscreteVector<DDimY> {1}));
-    sil::exterior::Cochain cochain(chain, Kokkos::View<double*, Kokkos::HostSpace>("", 2), 1., 2.);
+    sil::exterior::Cochain
+            cochain(chain,
+                    Kokkos::View<double*, Kokkos::LayoutRight, Kokkos::HostSpace>("", 2),
+                    1.,
+                    2.);
     EXPECT_EQ(cochain.integrate(), 3.);
 }

--- a/tests/exterior/exterior.cpp
+++ b/tests/exterior/exterior.cpp
@@ -134,17 +134,23 @@ TEST(Boundary, 1Simplex)
                                           ddc::DiscreteVector<> {})));
 }
 
-/*
 TEST(Boundary, 2Simplex)
 {
     sil::exterior::Simplex
             simplex(ddc::DiscreteElement<DDimT, DDimX, DDimY, DDimZ> {0, 0, 0, 0},
                     ddc::DiscreteVector<DDimT, DDimX> {1, 1});
-    sil::exterior::Chain chain = sil::exterior::boundary(simplex);
+    sil::exterior::Chain chain = sil::exterior::boundary(
+            Kokkos::View<
+                    sil::exterior::Simplex<1, DDimT, DDimX, DDimY, DDimZ>*,
+                    Kokkos::HostSpace>("", 4),
+            simplex);
     EXPECT_TRUE(
             chain
             == sil::exterior::
-                    Chain(sil::exterior::
+                    Chain(Kokkos::View<
+                                  sil::exterior::Simplex<1, DDimT, DDimX, DDimY, DDimZ>*,
+                                  Kokkos::HostSpace>("", 4),
+                          sil::exterior::
                                   Simplex(ddc::DiscreteElement<
                                                   DDimT,
                                                   DDimX,
@@ -176,11 +182,18 @@ TEST(Boundary, 2Simplex)
     sil::exterior::Simplex simplex2(
             ddc::DiscreteElement<DDimT, DDimX, DDimY, DDimZ> {0, 0, 0, 0},
             ddc::DiscreteVector<DDimX, DDimZ> {1, 1});
-    sil::exterior::Chain chain2 = sil::exterior::boundary(simplex2);
+    sil::exterior::Chain chain2 = sil::exterior::boundary(
+            Kokkos::View<
+                    sil::exterior::Simplex<1, DDimT, DDimX, DDimY, DDimZ>*,
+                    Kokkos::HostSpace>("", 4),
+            simplex2);
     EXPECT_TRUE(
             chain2
             == sil::exterior::
-                    Chain(sil::exterior::
+                    Chain(Kokkos::View<
+                                  sil::exterior::Simplex<1, DDimT, DDimX, DDimY, DDimZ>*,
+                                  Kokkos::HostSpace>("", 4),
+                          sil::exterior::
                                   Simplex(ddc::DiscreteElement<
                                                   DDimT,
                                                   DDimX,
@@ -215,11 +228,18 @@ TEST(Boundary, 3Simplex)
     sil::exterior::Simplex
             simplex(ddc::DiscreteElement<DDimT, DDimX, DDimY, DDimZ> {0, 0, 0, 0},
                     ddc::DiscreteVector<DDimT, DDimY, DDimZ> {1, 1, 1});
-    sil::exterior::Chain chain = sil::exterior::boundary(simplex);
+    sil::exterior::Chain chain = sil::exterior::boundary(
+            Kokkos::View<
+                    sil::exterior::Simplex<2, DDimT, DDimX, DDimY, DDimZ>*,
+                    Kokkos::HostSpace>("", 6),
+            simplex);
     EXPECT_TRUE(
             chain
             == sil::exterior::
-                    Chain(sil::exterior::
+                    Chain(Kokkos::View<
+                                  sil::exterior::Simplex<2, DDimT, DDimX, DDimY, DDimZ>*,
+                                  Kokkos::HostSpace>("", 6),
+                          sil::exterior::
                                   Simplex(ddc::DiscreteElement<
                                                   DDimT,
                                                   DDimX,
@@ -267,11 +287,18 @@ TEST(Boundary, 3Simplex)
     sil::exterior::Simplex simplex2(
             ddc::DiscreteElement<DDimT, DDimX, DDimY, DDimZ> {0, 0, 0, 0},
             ddc::DiscreteVector<DDimX, DDimY, DDimZ> {1, 1, 1});
-    sil::exterior::Chain chain2 = sil::exterior::boundary(simplex2);
+    sil::exterior::Chain chain2 = sil::exterior::boundary(
+            Kokkos::View<
+                    sil::exterior::Simplex<2, DDimT, DDimX, DDimY, DDimZ>*,
+                    Kokkos::HostSpace>("", 6),
+            simplex2);
     EXPECT_TRUE(
             chain2
             == sil::exterior::
-                    Chain(sil::exterior::
+                    Chain(Kokkos::View<
+                                  sil::exterior::Simplex<2, DDimT, DDimX, DDimY, DDimZ>*,
+                                  Kokkos::HostSpace>("", 6),
+                          sil::exterior::
                                   Simplex(ddc::DiscreteElement<
                                                   DDimT,
                                                   DDimX,
@@ -318,6 +345,7 @@ TEST(Boundary, 3Simplex)
                                           ddc::DiscreteVector<DDimX, DDimY> {-1, -1})));
 }
 
+/*
 TEST(Boundary, Chain)
 {
     sil::exterior::Chain chain = sil::exterior::

--- a/tests/exterior/exterior.cpp
+++ b/tests/exterior/exterior.cpp
@@ -50,12 +50,14 @@ TEST(Chain, Optimization)
                   sil::exterior::
                           Simplex(ddc::DiscreteElement<DDimT, DDimX, DDimY, DDimZ> {0, 0, 0, 0},
                                   ddc::DiscreteVector<DDimX, DDimY> {1, 1}));
-    Kokkos::View<sil::exterior::Simplex<2, DDimT, DDimX, DDimY, DDimZ>*, Kokkos::HostSpace>
-            chain_alloc2("", 1);
-    chain_alloc2(0) = sil::exterior::
+    sil::exterior::Chain
+            chain2(Kokkos::View<
+                           sil::exterior::Simplex<2, DDimT, DDimX, DDimY, DDimZ>*,
+                           Kokkos::HostSpace>("", 1),
+                   1);
+    chain2[0] = sil::exterior::
             Simplex(ddc::DiscreteElement<DDimT, DDimX, DDimY, DDimZ> {0, 0, 0, 1},
                     ddc::DiscreteVector<DDimX, DDimY> {1, 1});
-    sil::exterior::Chain chain2(chain_alloc2, chain_alloc2.size());
     chain = chain
             + sil::exterior::
                     Simplex(ddc::DiscreteElement<DDimT, DDimX, DDimY, DDimZ> {0, 1, 1, 0},
@@ -524,7 +526,9 @@ TEST(Coboundary, Test)
 TEST(LocalChain, Test)
 {
     sil::exterior::LocalChain
-            chain(sil::exterior::
+            chain(Kokkos::View<
+                          ddc::DiscreteVector<DDimT, DDimX, DDimY, DDimZ>*,
+                          Kokkos::HostSpace>("", 3), sil::exterior::
                           Simplex(ddc::DiscreteElement<DDimT, DDimX, DDimY, DDimZ> {0, 0, 0, 0},
                                   ddc::DiscreteVector<DDimX> {1}),
                   sil::exterior::

--- a/tests/exterior/exterior.cpp
+++ b/tests/exterior/exterior.cpp
@@ -510,19 +510,27 @@ TEST(Cochain, Test)
     EXPECT_EQ(cochain.integrate(), -1.);
 }
 
-/*
 TEST(Coboundary, Test)
 {
     sil::exterior::Simplex
             simplex(ddc::DiscreteElement<DDimT, DDimX, DDimY, DDimZ> {0, 1, 0, 0},
                     ddc::DiscreteVector<DDimX, DDimY> {1, 1});
-    sil::exterior::Chain simplex_boundary = boundary(simplex);
-    sil::exterior::Cochain cochain_boundary(simplex_boundary, 5., 8., 3., 2.);
+    sil::exterior::Chain simplex_boundary = boundary(
+            Kokkos::View<
+                    sil::exterior::Simplex<1, DDimT, DDimX, DDimY, DDimZ>*,
+                    Kokkos::HostSpace>("", 4),
+            simplex);
+    sil::exterior::Cochain cochain_boundary(
+            simplex_boundary,
+            Kokkos::View<double*, Kokkos::HostSpace>("", 4),
+            5.,
+            8.,
+            3.,
+            2.);
     sil::exterior::Cosimplex cosimplex = sil::exterior::coboundary(cochain_boundary);
     EXPECT_EQ(cosimplex.simplex(), simplex);
     EXPECT_EQ(cosimplex.value(), 4.);
 }
-*/
 
 TEST(LocalChain, Test)
 {

--- a/tests/exterior/exterior.cpp
+++ b/tests/exterior/exterior.cpp
@@ -345,21 +345,30 @@ TEST(Boundary, 3Simplex)
                                           ddc::DiscreteVector<DDimX, DDimY> {-1, -1})));
 }
 
-/*
 TEST(Boundary, Chain)
 {
     sil::exterior::Chain chain = sil::exterior::
-            Chain(sil::exterior::
+            Chain(Kokkos::View<
+                          sil::exterior::Simplex<2, DDimT, DDimX, DDimY, DDimZ>*,
+                          Kokkos::HostSpace>("", 2),
+                  sil::exterior::
                           Simplex(ddc::DiscreteElement<DDimT, DDimX, DDimY, DDimZ> {0, 0, 0, 0},
                                   ddc::DiscreteVector<DDimX, DDimY> {1, 1}),
                   sil::exterior::
                           Simplex(ddc::DiscreteElement<DDimT, DDimX, DDimY, DDimZ> {0, 1, 0, 0},
                                   ddc::DiscreteVector<DDimX, DDimY> {1, 1}));
-    sil::exterior::Chain boundary_chain = sil::exterior::boundary(chain);
+    sil::exterior::Chain boundary_chain = sil::exterior::boundary(
+            Kokkos::View<
+                    sil::exterior::Simplex<1, DDimT, DDimX, DDimY, DDimZ>*,
+                    Kokkos::HostSpace>("", 8),
+            chain);
     EXPECT_TRUE(
             boundary_chain
             == sil::exterior::
-                    Chain(sil::exterior::
+                    Chain(Kokkos::View<
+                                  sil::exterior::Simplex<1, DDimT, DDimX, DDimY, DDimZ>*,
+                                  Kokkos::HostSpace>("", 8),
+                          sil::exterior::
                                   Simplex(ddc::DiscreteElement<
                                                   DDimT,
                                                   DDimX,
@@ -403,6 +412,7 @@ TEST(Boundary, Chain)
                                           ddc::DiscreteVector<DDimX> {-1})));
 }
 
+/*
 TEST(Boundary, PoincarreLemma2)
 {
     sil::exterior::Simplex simplex = sil::exterior::

--- a/tests/exterior/exterior.cpp
+++ b/tests/exterior/exterior.cpp
@@ -568,17 +568,18 @@ TEST(LocalChain, Test)
                                     ddc::DiscreteVector<DDimZ> {1})));
 }
 
-/*
 TEST(LocalCochain, Test)
 {
     sil::exterior::LocalChain
-            chain(sil::exterior::
+            chain(Kokkos::View<
+                          ddc::DiscreteVector<DDimT, DDimX, DDimY, DDimZ>*,
+                          Kokkos::HostSpace>("", 2),
+                  sil::exterior::
                           Simplex(ddc::DiscreteElement<DDimT, DDimX, DDimY, DDimZ> {0, 0, 0, 0},
                                   ddc::DiscreteVector<DDimX> {1}),
                   sil::exterior::
                           Simplex(ddc::DiscreteElement<DDimT, DDimX, DDimY, DDimZ> {0, 0, 0, 0},
                                   ddc::DiscreteVector<DDimY> {1}));
-    sil::exterior::Cochain cochain(chain, 1., 2.);
+    sil::exterior::Cochain cochain(chain, Kokkos::View<double*, Kokkos::HostSpace>("", 2), 1., 2.);
     EXPECT_EQ(cochain.integrate(), 3.);
 }
-*/

--- a/tests/exterior/exterior.cpp
+++ b/tests/exterior/exterior.cpp
@@ -43,10 +43,19 @@ struct DDimZ : ddc::UniformPointSampling<Z>
 
 TEST(Chain, Optimization)
 {
-    sil::exterior::Chain chain = sil::exterior::Chain(
-            sil::exterior::
-                    Simplex(ddc::DiscreteElement<DDimT, DDimX, DDimY, DDimZ> {0, 0, 0, 0},
-                            ddc::DiscreteVector<DDimX, DDimY> {1, 1}));
+    Kokkos::View<sil::exterior::Simplex<2, DDimT, DDimX, DDimY, DDimZ>*, Kokkos::HostSpace>
+            chain_alloc("", 5);
+    sil::exterior::Chain chain = sil::exterior::
+            Chain(chain_alloc,
+                  sil::exterior::
+                          Simplex(ddc::DiscreteElement<DDimT, DDimX, DDimY, DDimZ> {0, 0, 0, 0},
+                                  ddc::DiscreteVector<DDimX, DDimY> {1, 1}));
+    Kokkos::View<sil::exterior::Simplex<2, DDimT, DDimX, DDimY, DDimZ>*, Kokkos::HostSpace>
+            chain_alloc2("", 1);
+    chain_alloc2(0) = sil::exterior::
+            Simplex(ddc::DiscreteElement<DDimT, DDimX, DDimY, DDimZ> {0, 0, 0, 1},
+                    ddc::DiscreteVector<DDimX, DDimY> {1, 1});
+    sil::exterior::Chain chain2(chain_alloc2);
     chain = chain
             + sil::exterior::
                     Simplex(ddc::DiscreteElement<DDimT, DDimX, DDimY, DDimZ> {0, 1, 1, 0},
@@ -57,40 +66,29 @@ TEST(Chain, Optimization)
             - sil::exterior::
                     Simplex(ddc::DiscreteElement<DDimT, DDimX, DDimY, DDimZ> {0, 0, 0, 0},
                             ddc::DiscreteVector<DDimX, DDimY> {1, 1})
-            - sil::exterior::Chain(
-                    sil::exterior::
-                            Simplex(ddc::DiscreteElement<DDimT, DDimX, DDimY, DDimZ> {0, 0, 0, 1},
-                                    ddc::DiscreteVector<DDimX, DDimY> {1, 1}));
+            - chain2;
     chain.optimize();
-    EXPECT_TRUE(
-            chain
-            == sil::exterior::
-                    Chain(sil::exterior::
-                                  Simplex(ddc::DiscreteElement<
-                                                  DDimT,
-                                                  DDimX,
-                                                  DDimY,
-                                                  DDimZ> {0, 1, 0, 0},
-                                          ddc::DiscreteVector<DDimX, DDimY> {1, 1},
-                                          true),
-                          sil::exterior::
-                                  Simplex(ddc::DiscreteElement<
-                                                  DDimT,
-                                                  DDimX,
-                                                  DDimY,
-                                                  DDimZ> {1, 0, 0, 0},
-                                          ddc::DiscreteVector<DDimX, DDimY> {1, 1},
-                                          true),
-                          sil::exterior::
-                                  Simplex(ddc::DiscreteElement<
-                                                  DDimT,
-                                                  DDimX,
-                                                  DDimY,
-                                                  DDimZ> {0, 0, 0, 1},
-                                          ddc::DiscreteVector<DDimX, DDimY> {1, 1},
-                                          true)));
+    chain.resize();
+    Kokkos::View<sil::exterior::Simplex<2, DDimT, DDimX, DDimY, DDimZ>*, Kokkos::HostSpace>
+            chain_alloc3("", 3);
+    sil::exterior::Chain chain3 = sil::exterior::
+            Chain(chain_alloc3,
+                  sil::exterior::
+                          Simplex(ddc::DiscreteElement<DDimT, DDimX, DDimY, DDimZ> {0, 1, 0, 0},
+                                  ddc::DiscreteVector<DDimX, DDimY> {1, 1},
+                                  true),
+                  sil::exterior::
+                          Simplex(ddc::DiscreteElement<DDimT, DDimX, DDimY, DDimZ> {1, 0, 0, 0},
+                                  ddc::DiscreteVector<DDimX, DDimY> {1, 1},
+                                  true),
+                  sil::exterior::
+                          Simplex(ddc::DiscreteElement<DDimT, DDimX, DDimY, DDimZ> {0, 0, 0, 1},
+                                  ddc::DiscreteVector<DDimX, DDimY> {1, 1},
+                                  true));
+    EXPECT_TRUE(chain == chain3);
 }
 
+/*
 TEST(Boundary, 1Simplex)
 {
     sil::exterior::Simplex
@@ -480,3 +478,4 @@ TEST(LocalCochain, Test)
     sil::exterior::Cochain cochain(chain, 1., 2.);
     EXPECT_EQ(cochain.integrate(), 3.);
 }
+*/

--- a/tests/exterior/exterior.cpp
+++ b/tests/exterior/exterior.cpp
@@ -483,14 +483,17 @@ TEST(Form, Alias)
                                   ddc::DiscreteVector<DDimX, DDimY> {1, 1}));
     // Unfortunately CTAD cannot deduce template arguments
     sil::exterior::Form<typename decltype(chain)::simplex_type> cosimplex(chain[0], 0.);
-    sil::exterior::Form<decltype(chain)> cochain(chain, 0.);
+    sil::exterior::Form<decltype(chain)>
+            cochain(chain, Kokkos::View<double*, Kokkos::HostSpace>("", 1), 0.);
 }
 
-/*
 TEST(Cochain, Test)
 {
     sil::exterior::Chain
-            chain(sil::exterior::
+            chain(Kokkos::View<
+                          sil::exterior::Simplex<2, DDimT, DDimX, DDimY, DDimZ>*,
+                          Kokkos::HostSpace>("", 3),
+                  sil::exterior::
                           Simplex(ddc::DiscreteElement<DDimT, DDimX, DDimY, DDimZ> {0, 1, 0, 0},
                                   ddc::DiscreteVector<DDimX, DDimY> {1, 1}),
                   sil::exterior::
@@ -500,10 +503,12 @@ TEST(Cochain, Test)
                           Simplex(ddc::DiscreteElement<DDimT, DDimX, DDimY, DDimZ> {0, 0, 0, 1},
                                   ddc::DiscreteVector<DDimX, DDimY> {1, 1},
                                   true));
-    sil::exterior::Cochain cochain(chain, 0., 1., 2.);
+    sil::exterior::Cochain
+            cochain(chain, Kokkos::View<double*, Kokkos::HostSpace>("", 3), 0., 1., 2.);
     EXPECT_EQ(cochain.integrate(), -1.);
 }
 
+/*
 TEST(Coboundary, Test)
 {
     sil::exterior::Simplex

--- a/tests/exterior/exterior.cpp
+++ b/tests/exterior/exterior.cpp
@@ -522,13 +522,15 @@ TEST(Coboundary, Test)
     EXPECT_EQ(cosimplex.simplex(), simplex);
     EXPECT_EQ(cosimplex.value(), 4.);
 }
+*/
 
 TEST(LocalChain, Test)
 {
     sil::exterior::LocalChain
             chain(Kokkos::View<
                           ddc::DiscreteVector<DDimT, DDimX, DDimY, DDimZ>*,
-                          Kokkos::HostSpace>("", 3), sil::exterior::
+                          Kokkos::HostSpace>("", 4),
+                  sil::exterior::
                           Simplex(ddc::DiscreteElement<DDimT, DDimX, DDimY, DDimZ> {0, 0, 0, 0},
                                   ddc::DiscreteVector<DDimX> {1}),
                   sil::exterior::
@@ -540,12 +542,18 @@ TEST(LocalChain, Test)
                             ddc::DiscreteVector<DDimT> {1});
     chain = chain
             + sil::exterior::LocalChain(
+                    Kokkos::View<
+                            ddc::DiscreteVector<DDimT, DDimX, DDimY, DDimZ>*,
+                            Kokkos::HostSpace>("", 1),
                     sil::exterior::
                             Simplex(ddc::DiscreteElement<DDimT, DDimX, DDimY, DDimZ> {0, 0, 0, 0},
                                     ddc::DiscreteVector<DDimZ> {1}));
     EXPECT_TRUE(
             chain
             == sil::exterior::LocalChain(
+                    Kokkos::View<
+                            ddc::DiscreteVector<DDimT, DDimX, DDimY, DDimZ>*,
+                            Kokkos::HostSpace>("", 4),
                     sil::exterior::
                             Simplex(ddc::DiscreteElement<DDimT, DDimX, DDimY, DDimZ> {0, 0, 0, 0},
                                     ddc::DiscreteVector<DDimX> {1}),
@@ -560,6 +568,7 @@ TEST(LocalChain, Test)
                                     ddc::DiscreteVector<DDimZ> {1})));
 }
 
+/*
 TEST(LocalCochain, Test)
 {
     sil::exterior::LocalChain

--- a/tests/exterior/exterior.cpp
+++ b/tests/exterior/exterior.cpp
@@ -43,10 +43,10 @@ struct DDimZ : ddc::UniformPointSampling<Z>
 
 TEST(Chain, Optimization)
 {
-    Kokkos::View<sil::exterior::Simplex<2, DDimT, DDimX, DDimY, DDimZ>*, Kokkos::HostSpace>
-            chain_alloc("", 5);
     sil::exterior::Chain chain = sil::exterior::
-            Chain(chain_alloc,
+            Chain(Kokkos::View<
+                          sil::exterior::Simplex<2, DDimT, DDimX, DDimY, DDimZ>*,
+                          Kokkos::HostSpace>("", 5),
                   sil::exterior::
                           Simplex(ddc::DiscreteElement<DDimT, DDimX, DDimY, DDimZ> {0, 0, 0, 0},
                                   ddc::DiscreteVector<DDimX, DDimY> {1, 1}));
@@ -69,23 +69,36 @@ TEST(Chain, Optimization)
             - chain2;
     chain.optimize();
     chain.resize();
-    Kokkos::View<sil::exterior::Simplex<2, DDimT, DDimX, DDimY, DDimZ>*, Kokkos::HostSpace>
-            chain_alloc3("", 3);
-    sil::exterior::Chain chain3 = sil::exterior::
-            Chain(chain_alloc3,
-                  sil::exterior::
-                          Simplex(ddc::DiscreteElement<DDimT, DDimX, DDimY, DDimZ> {0, 1, 0, 0},
-                                  ddc::DiscreteVector<DDimX, DDimY> {1, 1},
-                                  true),
-                  sil::exterior::
-                          Simplex(ddc::DiscreteElement<DDimT, DDimX, DDimY, DDimZ> {1, 0, 0, 0},
-                                  ddc::DiscreteVector<DDimX, DDimY> {1, 1},
-                                  true),
-                  sil::exterior::
-                          Simplex(ddc::DiscreteElement<DDimT, DDimX, DDimY, DDimZ> {0, 0, 0, 1},
-                                  ddc::DiscreteVector<DDimX, DDimY> {1, 1},
-                                  true));
-    EXPECT_TRUE(chain == chain3);
+    EXPECT_TRUE(
+            chain
+            == sil::exterior::
+                    Chain(Kokkos::View<
+                                  sil::exterior::Simplex<2, DDimT, DDimX, DDimY, DDimZ>*,
+                                  Kokkos::HostSpace>("", 3),
+                          sil::exterior::
+                                  Simplex(ddc::DiscreteElement<
+                                                  DDimT,
+                                                  DDimX,
+                                                  DDimY,
+                                                  DDimZ> {0, 1, 0, 0},
+                                          ddc::DiscreteVector<DDimX, DDimY> {1, 1},
+                                          true),
+                          sil::exterior::
+                                  Simplex(ddc::DiscreteElement<
+                                                  DDimT,
+                                                  DDimX,
+                                                  DDimY,
+                                                  DDimZ> {1, 0, 0, 0},
+                                          ddc::DiscreteVector<DDimX, DDimY> {1, 1},
+                                          true),
+                          sil::exterior::
+                                  Simplex(ddc::DiscreteElement<
+                                                  DDimT,
+                                                  DDimX,
+                                                  DDimY,
+                                                  DDimZ> {0, 0, 0, 1},
+                                          ddc::DiscreteVector<DDimX, DDimY> {1, 1},
+                                          true)));
 }
 
 TEST(Boundary, 1Simplex)
@@ -93,15 +106,17 @@ TEST(Boundary, 1Simplex)
     sil::exterior::Simplex
             simplex(ddc::DiscreteElement<DDimT, DDimX, DDimY, DDimZ> {0, 0, 0, 0},
                     ddc::DiscreteVector<DDimX> {1});
-    Kokkos::View<sil::exterior::Simplex<0, DDimT, DDimX, DDimY, DDimZ>*, Kokkos::HostSpace>
-            chain_alloc("", 2);
-    sil::exterior::Chain chain = sil::exterior::boundary(chain_alloc, simplex);
-    Kokkos::View<sil::exterior::Simplex<0, DDimT, DDimX, DDimY, DDimZ>*, Kokkos::HostSpace>
-            chain_alloc2("", 2);
+    sil::exterior::Chain chain = sil::exterior::boundary(
+            Kokkos::View<
+                    sil::exterior::Simplex<0, DDimT, DDimX, DDimY, DDimZ>*,
+                    Kokkos::HostSpace>("", 2),
+            simplex);
     EXPECT_TRUE(
             chain
             == sil::exterior::
-                    Chain(chain_alloc2,
+                    Chain(Kokkos::View<
+                                  sil::exterior::Simplex<0, DDimT, DDimX, DDimY, DDimZ>*,
+                                  Kokkos::HostSpace>("", 2),
                           sil::exterior::
                                   Simplex(ddc::DiscreteElement<
                                                   DDimT,


### PR DESCRIPTION
Kokkos::View constructors involving allocation are non-KOKKOS_FUNCTION, so we need to pass all needed allocations to the functions.