### PR TITLE
[[maybe_unused]] attribute on every TensorAccessor

### DIFF
--- a/examples/2d_laplacian.cpp
+++ b/examples/2d_laplacian.cpp
@@ -86,7 +86,7 @@ int main(int argc, char** argv)
             ddc::detail::TypeSeq<BSplinesX, BSplinesY>>(lower_bounds, upper_bounds, nb_cells);
 
     // Allocate and instantiate a metric tensor field.
-    sil::tensor::TensorAccessor<MetricIndex> metric_accessor;
+    [[maybe_unused]] sil::tensor::TensorAccessor<MetricIndex> metric_accessor;
     ddc::DiscreteDomain<DDimX, DDimY, MetricIndex>
             metric_dom(mesh_xy, metric_accessor.mem_domain());
     ddc::Chunk metric_alloc(metric_dom, ddc::HostAllocator<double>());
@@ -103,7 +103,8 @@ int main(int argc, char** argv)
     });
 
     // Invert metric
-    sil::tensor::TensorAccessor<sil::tensor::upper<MetricIndex>> inv_metric_accessor;
+    [[maybe_unused]] sil::tensor::TensorAccessor<sil::tensor::upper<MetricIndex>>
+            inv_metric_accessor;
     ddc::DiscreteDomain<DDimX, DDimY, sil::tensor::upper<MetricIndex>>
             inv_metric_dom(mesh_xy, inv_metric_accessor.mem_domain());
     ddc::Chunk inv_metric_alloc(inv_metric_dom, ddc::HostAllocator<double>());
@@ -116,7 +117,7 @@ int main(int argc, char** argv)
     sil::tensor::fill_inverse_metric<MetricIndex>(inv_metric, metric);
 
     // Potential
-    sil::tensor::TensorAccessor<DummyIndex> potential_accessor;
+    [[maybe_unused]] sil::tensor::TensorAccessor<DummyIndex> potential_accessor;
     ddc::DiscreteDomain<DDimX, DDimY, DummyIndex>
             potential_dom(metric.non_indices_domain(), potential_accessor.mem_domain());
     ddc::Chunk potential_alloc(potential_dom, ddc::HostAllocator<double>());
@@ -146,7 +147,7 @@ int main(int argc, char** argv)
     std::cout << potential[potential_accessor.mem_domain().front()] << std::endl;
 
     // Gradient
-    sil::tensor::TensorAccessor<MuLow> gradient_accessor;
+    [[maybe_unused]] sil::tensor::TensorAccessor<MuLow> gradient_accessor;
     ddc::DiscreteDomain<DDimX, DDimY, MuLow> gradient_dom(mesh_xy, gradient_accessor.mem_domain());
     ddc::Chunk gradient_alloc(gradient_dom, ddc::HostAllocator<double>());
     sil::tensor::Tensor<
@@ -175,7 +176,7 @@ int main(int argc, char** argv)
             ddc::detail::TypeSeq<NuLow>>(hodge_star, inv_metric);
 
     // Dual gradient
-    sil::tensor::TensorAccessor<NuLow> dual_gradient_accessor;
+    [[maybe_unused]] sil::tensor::TensorAccessor<NuLow> dual_gradient_accessor;
     ddc::DiscreteDomain<DDimX, DDimY, NuLow>
             dual_gradient_dom(mesh_xy, dual_gradient_accessor.mem_domain());
     ddc::Chunk dual_gradient_alloc(dual_gradient_dom, ddc::HostAllocator<double>());
@@ -191,8 +192,8 @@ int main(int argc, char** argv)
     });
 
     // Dual Laplacian
-    sil::tensor::TensorAccessor<sil::tensor::TensorAntisymmetricIndex<RhoLow, NuLow>>
-            dual_laplacian_accessor;
+    [[maybe_unused]] sil::tensor::TensorAccessor<
+            sil::tensor::TensorAntisymmetricIndex<RhoLow, NuLow>> dual_laplacian_accessor;
     ddc::DiscreteDomain<DDimX, DDimY, sil::tensor::TensorAntisymmetricIndex<RhoLow, NuLow>>
             dual_laplacian_dom(
                     mesh_xy.remove_last(ddc::DiscreteVector<DDimX, DDimY> {1, 1}),
@@ -224,7 +225,7 @@ int main(int argc, char** argv)
             ddc::detail::TypeSeq<>>(hodge_star2, inv_metric);
 
     // Laplacian
-    sil::tensor::TensorAccessor<DummyIndex> laplacian_accessor;
+    [[maybe_unused]] sil::tensor::TensorAccessor<DummyIndex> laplacian_accessor;
     ddc::DiscreteDomain<DDimX, DDimY, DummyIndex> laplacian_dom(
             mesh_xy.remove_last(ddc::DiscreteVector<DDimX, DDimY> {1, 1}),
             laplacian_accessor.mem_domain());

--- a/examples/2d_laplacian.cpp
+++ b/examples/2d_laplacian.cpp
@@ -159,7 +159,7 @@ int main(int argc, char** argv)
     sil::exterior::deriv<MuLow, DummyIndex>(gradient, potential);
 
     // Hodge star
-    sil::tensor::tensor_accessor_for_domain_t<HodgeStarDomain> hodge_star_accessor;
+    [[maybe_unused]] sil::tensor::tensor_accessor_for_domain_t<HodgeStarDomain> hodge_star_accessor;
     ddc::cartesian_prod_t<ddc::DiscreteDomain<DDimX, DDimY>, HodgeStarDomain>
             hodge_star_dom(metric.non_indices_domain(), hodge_star_accessor.mem_domain());
     ddc::Chunk hodge_star_alloc(hodge_star_dom, ddc::HostAllocator<double>());
@@ -208,7 +208,8 @@ int main(int argc, char** argv)
     sil::exterior::deriv<RhoLow, NuLow>(dual_laplacian, dual_gradient);
 
     // Hodge star 2
-    sil::tensor::tensor_accessor_for_domain_t<HodgeStarDomain2> hodge_star_accessor2;
+    [[maybe_unused]] sil::tensor::tensor_accessor_for_domain_t<HodgeStarDomain2>
+            hodge_star_accessor2;
     ddc::cartesian_prod_t<ddc::DiscreteDomain<DDimX, DDimY>, HodgeStarDomain2>
             hodge_star_dom2(metric.non_indices_domain(), hodge_star_accessor2.mem_domain());
     ddc::Chunk hodge_star_alloc2(hodge_star_dom2, ddc::HostAllocator<double>());

--- a/examples/kretschmann_scalar.cpp
+++ b/examples/kretschmann_scalar.cpp
@@ -80,7 +80,7 @@ int main(int argc, char** argv)
     ddc::ScopeGuard const ddc_scope(argc, argv);
 
     // Allocate and instantiate a metric tensor. Because the metric in Lorentzian, the size of the allocation is 0 (metric_dom is empty).
-    sil::tensor::TensorAccessor<MetricIndex> metric_accessor;
+    [[maybe_unused]] sil::tensor::TensorAccessor<MetricIndex> metric_accessor;
     ddc::DiscreteDomain<MetricIndex> metric_dom = metric_accessor.mem_domain();
     ddc::Chunk metric_alloc(metric_dom, ddc::HostAllocator<double>());
     sil::tensor::Tensor<
@@ -91,7 +91,7 @@ int main(int argc, char** argv)
             metric(metric_alloc);
 
     // Allocate and instantiate a fully-contravariant Riemann tensor. The size of the allocation is 20 because the Riemann tensor has 20 independant components.
-    sil::tensor::TensorAccessor<RiemannUpTensorIndex> riemann_up_accessor;
+    [[maybe_unused]] sil::tensor::TensorAccessor<RiemannUpTensorIndex> riemann_up_accessor;
     ddc::DiscreteDomain<RiemannUpTensorIndex> riemann_up_dom = riemann_up_accessor.mem_domain();
     ddc::Chunk riemann_up_alloc(riemann_up_dom, ddc::HostAllocator<double>());
     sil::tensor::Tensor<

--- a/tests/csr/csr.cpp
+++ b/tests/csr/csr.cpp
@@ -36,7 +36,7 @@ struct Gamma : sil::tensor::TensorNaturalIndex<X, Y, Z>
 
 TEST(CsrDynamic, Csr2Dense)
 {
-    sil::tensor::TensorAccessor<Alpha, Beta, Gamma> tensor_accessor;
+    [[maybe_unused]] sil::tensor::TensorAccessor<Alpha, Beta, Gamma> tensor_accessor;
     ddc::DiscreteDomain<Alpha, Beta, Gamma> tensor_dom = tensor_accessor.mem_domain();
     ddc::Chunk tensor_alloc(tensor_dom, ddc::HostAllocator<double>());
     sil::tensor::Tensor<
@@ -103,7 +103,7 @@ TEST(CsrDynamic, Csr2Dense)
 
 TEST(Csr, CsrDenseProducts)
 {
-    sil::tensor::TensorAccessor<Alpha, Beta, Gamma> tensor_accessor;
+    [[maybe_unused]] sil::tensor::TensorAccessor<Alpha, Beta, Gamma> tensor_accessor;
     ddc::DiscreteDomain<Alpha, Beta, Gamma> tensor_dom = tensor_accessor.mem_domain();
     ddc::Chunk tensor_alloc(tensor_dom, ddc::HostAllocator<double>());
     sil::tensor::Tensor<
@@ -132,7 +132,7 @@ TEST(Csr, CsrDenseProducts)
 
     sil::csr::Csr<9, Alpha, Beta, Gamma> csr(csr_dyn);
 
-    sil::tensor::TensorAccessor<Beta, Gamma> right_tensor_accessor;
+    [[maybe_unused]] sil::tensor::TensorAccessor<Beta, Gamma> right_tensor_accessor;
     ddc::DiscreteDomain<Beta, Gamma> right_tensor_dom = right_tensor_accessor.mem_domain();
     ddc::Chunk right_tensor_alloc(right_tensor_dom, ddc::HostAllocator<double>());
     sil::tensor::Tensor<
@@ -143,7 +143,7 @@ TEST(Csr, CsrDenseProducts)
             right_tensor(right_tensor_alloc);
     ddc::parallel_fill(right_tensor, 1.);
 
-    sil::tensor::TensorAccessor<Alpha> right_prod_accessor;
+    [[maybe_unused]] sil::tensor::TensorAccessor<Alpha> right_prod_accessor;
     ddc::DiscreteDomain<Alpha> right_prod_dom = right_prod_accessor.mem_domain();
     ddc::Chunk right_prod_alloc(right_prod_dom, ddc::HostAllocator<double>());
     sil::tensor::Tensor<
@@ -159,7 +159,7 @@ TEST(Csr, CsrDenseProducts)
     EXPECT_EQ(right_prod.get(right_prod_accessor.access_element<Y>()), 12.);
     EXPECT_EQ(right_prod.get(right_prod_accessor.access_element<Z>()), 30.);
 
-    sil::tensor::TensorAccessor<Alpha> left_vector_accessor;
+    [[maybe_unused]] sil::tensor::TensorAccessor<Alpha> left_vector_accessor;
     ddc::DiscreteDomain<Alpha> left_vector_dom = left_vector_accessor.mem_domain();
     ddc::Chunk left_vector_alloc(left_vector_dom, ddc::HostAllocator<double>());
     sil::tensor::Tensor<
@@ -170,7 +170,7 @@ TEST(Csr, CsrDenseProducts)
             left_vector(left_vector_alloc);
     ddc::parallel_fill(left_vector, 1.);
 
-    sil::tensor::TensorAccessor<Beta, Gamma> left_prod_accessor;
+    [[maybe_unused]] sil::tensor::TensorAccessor<Beta, Gamma> left_prod_accessor;
     ddc::DiscreteDomain<Beta, Gamma> left_prod_dom = left_prod_accessor.mem_domain();
     ddc::Chunk left_prod_alloc(left_prod_dom, ddc::HostAllocator<double>());
     sil::tensor::Tensor<

--- a/tests/exterior/derivative.cpp
+++ b/tests/exterior/derivative.cpp
@@ -15,7 +15,7 @@
 template <std::size_t N, bool CoalescentIndexing, class InIndex, class OutIndex, class... DDim>
 static auto test_derivative()
 {
-    sil::tensor::TensorAccessor<InIndex> tensor_accessor;
+    [[maybe_unused]] sil::tensor::TensorAccessor<InIndex> tensor_accessor;
     if constexpr (CoalescentIndexing) {
         ddc::DiscreteDomain<InIndex, DDim...>
                 dom(tensor_accessor.mem_domain(),
@@ -41,7 +41,7 @@ static auto test_derivative()
                          ddc::DiscreteElement<InIndex>(i))
                     = i + 2.;
         }
-        sil::tensor::TensorAccessor<OutIndex> derivative_accessor;
+        [[maybe_unused]] sil::tensor::TensorAccessor<OutIndex> derivative_accessor;
         ddc::DiscreteDomain<OutIndex, DDim...> derivative_dom(
                 derivative_accessor.mem_domain(),
                 ddc::DiscreteDomain(
@@ -92,7 +92,7 @@ static auto test_derivative()
                          ddc::DiscreteElement<InIndex>(i))
                     = i + 2.;
         }
-        sil::tensor::TensorAccessor<OutIndex> derivative_accessor;
+        [[maybe_unused]] sil::tensor::TensorAccessor<OutIndex> derivative_accessor;
         ddc::DiscreteDomain<DDim..., OutIndex> derivative_dom(
                 ddc::DiscreteDomain(
                         sil::misc::filled_struct<ddc::DiscreteElement<DDim...>>(0),
@@ -911,8 +911,8 @@ struct IndexSpect : sil::tensor::TensorSymmetricIndex<SpectNatIndex1, SpectNatIn
 TEST(ExteriorDerivative, 2DRotationalWithSpects)
 {
     const std::size_t N = 3;
-    sil::tensor::TensorAccessor<IndexSpect, sil::tensor::TensorAntisymmetricIndex<Mu2>>
-            tensor_accessor;
+    [[maybe_unused]] sil::tensor::
+            TensorAccessor<IndexSpect, sil::tensor::TensorAntisymmetricIndex<Mu2>> tensor_accessor;
     ddc::DiscreteDomain<
             sil::tensor::TensorAntisymmetricIndex<Mu2>,
             DDimSpect,
@@ -958,8 +958,9 @@ TEST(ExteriorDerivative, 2DRotationalWithSpects)
         }
     }
 
-    sil::tensor::TensorAccessor<IndexSpect, sil::tensor::TensorAntisymmetricIndex<Nu2, Mu2>>
-            derivative_accessor;
+    [[maybe_unused]] sil::tensor::TensorAccessor<
+            IndexSpect,
+            sil::tensor::TensorAntisymmetricIndex<Nu2, Mu2>> derivative_accessor;
     ddc::DiscreteDomain<
             sil::tensor::TensorAntisymmetricIndex<Nu2, Mu2>,
             DDimSpect,

--- a/tests/exterior/hodge_star.cpp
+++ b/tests/exterior/hodge_star.cpp
@@ -69,7 +69,7 @@ TEST(HodgeStar, Test)
             mesh_xy(ddc::DiscreteElement<DDimX, DDimY>(0, 0),
                     ddc::DiscreteVector<DDimX, DDimY>(3, 3));
 
-    sil::tensor::TensorAccessor<MetricIndex> metric_accessor;
+    [[maybe_unused]] sil::tensor::TensorAccessor<MetricIndex> metric_accessor;
     ddc::DiscreteDomain<DDimX, DDimY, MetricIndex>
             metric_dom(mesh_xy, metric_accessor.mem_domain());
     ddc::Chunk metric_alloc(metric_dom, ddc::HostAllocator<double>());
@@ -104,7 +104,8 @@ TEST(HodgeStar, Test)
             ddc::detail::TypeSeq<MuUp, NuUp>,
             ddc::detail::TypeSeq<RhoLow>>(hodge_star, metric);
 
-    sil::tensor::TensorAccessor<sil::tensor::TensorAntisymmetricIndex<MuLow, NuLow>> form_accessor;
+    [[maybe_unused]] sil::tensor::TensorAccessor<
+            sil::tensor::TensorAntisymmetricIndex<MuLow, NuLow>> form_accessor;
     ddc::DiscreteDomain<DDimX, DDimY, sil::tensor::TensorAntisymmetricIndex<MuLow, NuLow>>
             form_dom(metric.non_indices_domain(), form_accessor.mem_domain());
     ddc::Chunk form_alloc(form_dom, ddc::HostAllocator<double>());
@@ -120,7 +121,7 @@ TEST(HodgeStar, Test)
         form(elem, form.accessor().access_element<Y, Z>()) = 3.;
     });
 
-    sil::tensor::TensorAccessor<RhoLow> dual_form_accessor;
+    [[maybe_unused]] sil::tensor::TensorAccessor<RhoLow> dual_form_accessor;
     ddc::DiscreteDomain<DDimX, DDimY, RhoLow>
             dual_form_dom(metric.non_indices_domain(), dual_form_accessor.mem_domain());
     ddc::Chunk dual_form_alloc(dual_form_dom, ddc::HostAllocator<double>());

--- a/tests/exterior/hodge_star.cpp
+++ b/tests/exterior/hodge_star.cpp
@@ -88,7 +88,7 @@ TEST(HodgeStar, Test)
         metric(elem, metric.accessor().access_element<Z, Z>()) = 6.;
     });
 
-    sil::tensor::tensor_accessor_for_domain_t<HodgeStarDomain> hodge_star_accessor;
+    [[maybe_unused]] sil::tensor::tensor_accessor_for_domain_t<HodgeStarDomain> hodge_star_accessor;
     ddc::cartesian_prod_t<ddc::DiscreteDomain<DDimX, DDimY>, HodgeStarDomain>
             hodge_star_dom(metric.non_indices_domain(), hodge_star_accessor.mem_domain());
     ddc::Chunk hodge_star_alloc(hodge_star_dom, ddc::HostAllocator<double>());
@@ -136,7 +136,8 @@ TEST(HodgeStar, Test)
         sil::tensor::tensor_prod(dual_form[elem], hodge_star[elem], form[elem]);
     });
 
-    sil::tensor::tensor_accessor_for_domain_t<HodgeStarDomain2> hodge_star_accessor2;
+    [[maybe_unused]] sil::tensor::tensor_accessor_for_domain_t<HodgeStarDomain2>
+            hodge_star_accessor2;
     ddc::cartesian_prod_t<ddc::DiscreteDomain<DDimX, DDimY>, HodgeStarDomain2>
             hodge_star_dom2(metric.non_indices_domain(), hodge_star_accessor2.mem_domain());
     ddc::Chunk hodge_star_alloc2(hodge_star_dom2, ddc::HostAllocator<double>());

--- a/tests/tensor/metric.cpp
+++ b/tests/tensor/metric.cpp
@@ -39,7 +39,7 @@ TEST(Metric, MetricLike)
             mesh_xy(ddc::DiscreteElement<DDimX, DDimY>(0, 0),
                     ddc::DiscreteVector<DDimX, DDimY>(10, 10));
 
-    sil::tensor::TensorAccessor<MetricLikeIndex> metric_accessor;
+    [[maybe_unused]] sil::tensor::TensorAccessor<MetricLikeIndex> metric_accessor;
     ddc::DiscreteDomain<DDimX, DDimY, MetricLikeIndex>
             metric_dom(mesh_xy, metric_accessor.mem_domain());
 
@@ -75,7 +75,7 @@ TEST(Metric, Covariant)
             mesh_xy(ddc::DiscreteElement<DDimX, DDimY>(0, 0),
                     ddc::DiscreteVector<DDimX, DDimY>(10, 10));
 
-    sil::tensor::TensorAccessor<MetricIndex> metric_accessor;
+    [[maybe_unused]] sil::tensor::TensorAccessor<MetricIndex> metric_accessor;
     ddc::DiscreteDomain<DDimX, DDimY, MetricIndex>
             metric_dom(mesh_xy, metric_accessor.mem_domain());
     ddc::Chunk metric_alloc(metric_dom, ddc::HostAllocator<double>());
@@ -112,7 +112,7 @@ TEST(Metric, ChristoffelLike)
             mesh_xy(ddc::DiscreteElement<DDimX, DDimY>(0, 0),
                     ddc::DiscreteVector<DDimX, DDimY>(10, 10));
 
-    sil::tensor::TensorAccessor<MetricIndex> metric_accessor;
+    [[maybe_unused]] sil::tensor::TensorAccessor<MetricIndex> metric_accessor;
     ddc::DiscreteDomain<DDimX, DDimY, MetricIndex>
             metric_dom(mesh_xy, metric_accessor.mem_domain());
     ddc::Chunk metric_alloc(metric_dom, ddc::HostAllocator<double>());
@@ -128,7 +128,7 @@ TEST(Metric, ChristoffelLike)
         metric(elem, metric.accessor().access_element<Y, Y>()) = 2.;
     });
 
-    sil::tensor::TensorAccessor<KUp, sil::tensor::TensorSymmetricIndex<ILow, JLow>>
+    [[maybe_unused]] sil::tensor::TensorAccessor<KUp, sil::tensor::TensorSymmetricIndex<ILow, JLow>>
             christoffel_1st_accessor;
     ddc::DiscreteDomain<DDimX, DDimY, KUp, sil::tensor::TensorSymmetricIndex<ILow, JLow>>
             christoffel_1st_dom(mesh_xy, christoffel_1st_accessor.mem_domain());
@@ -231,7 +231,7 @@ TEST(Metric, Inverse)
             mesh_xy(ddc::DiscreteElement<DDimX, DDimY>(0, 0),
                     ddc::DiscreteVector<DDimX, DDimY>(10, 10));
 
-    sil::tensor::TensorAccessor<DirectMetricIndex> metric_accessor;
+    [[maybe_unused]] sil::tensor::TensorAccessor<DirectMetricIndex> metric_accessor;
     ddc::DiscreteDomain<DDimX, DDimY, DirectMetricIndex>
             metric_dom(mesh_xy, metric_accessor.mem_domain());
     ddc::Chunk metric_alloc(metric_dom, ddc::HostAllocator<double>());
@@ -250,7 +250,7 @@ TEST(Metric, Inverse)
         metric(elem, metric.accessor().access_element<Z, Z>()) = 6.;
     });
 
-    sil::tensor::TensorAccessor<InvMetricIndex> inv_metric_accessor;
+    [[maybe_unused]] sil::tensor::TensorAccessor<InvMetricIndex> inv_metric_accessor;
     ddc::DiscreteDomain<DDimX, DDimY, InvMetricIndex>
             inv_metric_dom(mesh_xy, inv_metric_accessor.mem_domain());
     ddc::Chunk inv_metric_alloc(inv_metric_dom, ddc::HostAllocator<double>());
@@ -263,7 +263,7 @@ TEST(Metric, Inverse)
 
     sil::tensor::fill_inverse_metric<DirectMetricIndex>(inv_metric, metric);
 
-    sil::tensor::TensorAccessor<IdIndex> identity_accessor;
+    [[maybe_unused]] sil::tensor::TensorAccessor<IdIndex> identity_accessor;
     ddc::DiscreteDomain<DDimX, DDimY, IdIndex>
             identity_dom(mesh_xy, identity_accessor.mem_domain());
     ddc::Chunk identity_alloc(identity_dom, ddc::HostAllocator<double>());

--- a/tests/tensor/tensor.cpp
+++ b/tests/tensor/tensor.cpp
@@ -51,7 +51,7 @@ struct Nu : sil::tensor::TensorNaturalIndex<T, X, Y, Z>
 
 TEST(Tensor, NaturalIndexing)
 {
-    sil::tensor::TensorAccessor<Alpha, Nu> tensor_accessor;
+    [[maybe_unused]] sil::tensor::TensorAccessor<Alpha, Nu> tensor_accessor;
     ddc::DiscreteDomain<Alpha, Nu> tensor_dom = tensor_accessor.mem_domain();
     ddc::Chunk tensor_alloc(tensor_dom, ddc::HostAllocator<double>());
     sil::tensor::Tensor<
@@ -100,7 +100,7 @@ using FullIndex = sil::tensor::TensorFullIndex<Alpha, Nu>;
 
 TEST(Tensor, TensorFullIndexing)
 {
-    sil::tensor::TensorAccessor<FullIndex> tensor_accessor;
+    [[maybe_unused]] sil::tensor::TensorAccessor<FullIndex> tensor_accessor;
     ddc::DiscreteDomain<FullIndex> tensor_dom = tensor_accessor.mem_domain();
     ddc::Chunk tensor_alloc(tensor_dom, ddc::HostAllocator<double>());
     sil::tensor::Tensor<
@@ -149,7 +149,7 @@ using IdIndex = sil::tensor::TensorIdentityIndex<Mu, Nu>;
 
 TEST(Tensor, TensorIdentityIndexing)
 {
-    sil::tensor::TensorAccessor<IdIndex> tensor_accessor;
+    [[maybe_unused]] sil::tensor::TensorAccessor<IdIndex> tensor_accessor;
     ddc::DiscreteDomain<IdIndex> tensor_dom = tensor_accessor.mem_domain();
     ddc::Chunk tensor_alloc(tensor_dom, ddc::HostAllocator<double>());
     sil::tensor::Tensor<
@@ -182,7 +182,7 @@ using LorentzianSignIndex
 
 TEST(Tensor, TensorLorentzianSignIndexing)
 {
-    sil::tensor::TensorAccessor<LorentzianSignIndex> tensor_accessor;
+    [[maybe_unused]] sil::tensor::TensorAccessor<LorentzianSignIndex> tensor_accessor;
     ddc::DiscreteDomain<LorentzianSignIndex> tensor_dom = tensor_accessor.mem_domain();
     ddc::Chunk tensor_alloc(tensor_dom, ddc::HostAllocator<double>());
     sil::tensor::Tensor<
@@ -214,7 +214,7 @@ using DiagIndex = sil::tensor::TensorDiagonalIndex<Mu, Nu>;
 
 TEST(Tensor, TensorDiagonalIndexing)
 {
-    sil::tensor::TensorAccessor<DiagIndex> tensor_accessor;
+    [[maybe_unused]] sil::tensor::TensorAccessor<DiagIndex> tensor_accessor;
     ddc::DiscreteDomain<DiagIndex> tensor_dom = tensor_accessor.mem_domain();
     ddc::Chunk tensor_alloc(tensor_dom, ddc::HostAllocator<double>());
     sil::tensor::Tensor<
@@ -257,7 +257,7 @@ using SymIndex = sil::tensor::TensorSymmetricIndex<Mu, Nu>;
 
 TEST(Tensor, TensorSymmetricIndexing4x4)
 {
-    sil::tensor::TensorAccessor<SymIndex> tensor_accessor;
+    [[maybe_unused]] sil::tensor::TensorAccessor<SymIndex> tensor_accessor;
     ddc::DiscreteDomain<SymIndex> tensor_dom = tensor_accessor.mem_domain();
     ddc::Chunk tensor_alloc(tensor_dom, ddc::HostAllocator<double>());
     sil::tensor::Tensor<
@@ -307,7 +307,7 @@ using SymIndex3x3x3 = sil::tensor::TensorSymmetricIndex<Alpha, Beta, Gamma>;
 
 TEST(Tensor, TensorSymmetricIndexing3x3x3)
 {
-    sil::tensor::TensorAccessor<SymIndex3x3x3> tensor_accessor;
+    [[maybe_unused]] sil::tensor::TensorAccessor<SymIndex3x3x3> tensor_accessor;
     ddc::DiscreteDomain<SymIndex3x3x3> tensor_dom = tensor_accessor.mem_domain();
     ddc::Chunk tensor_alloc(tensor_dom, ddc::HostAllocator<double>());
     sil::tensor::Tensor<
@@ -367,7 +367,7 @@ using AntisymIndex = sil::tensor::TensorAntisymmetricIndex<Mu, Nu>;
 
 TEST(Tensor, TensorAntisymmetricIndexing4x4)
 {
-    sil::tensor::TensorAccessor<AntisymIndex> tensor_accessor;
+    [[maybe_unused]] sil::tensor::TensorAccessor<AntisymIndex> tensor_accessor;
     ddc::DiscreteDomain<AntisymIndex> tensor_dom = tensor_accessor.mem_domain();
     ddc::Chunk tensor_alloc(tensor_dom, ddc::HostAllocator<double>());
     sil::tensor::Tensor<
@@ -412,7 +412,7 @@ using LeviCivitaIndex = sil::tensor::TensorLeviCivitaIndex<Alpha, Beta, Gamma>;
 
 TEST(Tensor, TensorLeviCivitaIndexing)
 {
-    sil::tensor::TensorAccessor<LeviCivitaIndex> tensor_accessor;
+    [[maybe_unused]] sil::tensor::TensorAccessor<LeviCivitaIndex> tensor_accessor;
     ddc::DiscreteDomain<LeviCivitaIndex> tensor_dom = tensor_accessor.mem_domain();
     ddc::Chunk tensor_alloc(tensor_dom, ddc::HostAllocator<double>());
     sil::tensor::Tensor<
@@ -455,7 +455,7 @@ using SymIndex3x3 = sil::tensor::TensorSymmetricIndex<Alpha, Beta>;
 
 TEST(Tensor, PartiallyTensorSymmetricIndexing4x3x3)
 {
-    sil::tensor::TensorAccessor<Mu, SymIndex3x3> tensor_accessor;
+    [[maybe_unused]] sil::tensor::TensorAccessor<Mu, SymIndex3x3> tensor_accessor;
     ddc::DiscreteDomain<Mu, SymIndex3x3> tensor_dom = tensor_accessor.mem_domain();
     ddc::Chunk tensor_alloc(tensor_dom, ddc::HostAllocator<double>());
     sil::tensor::Tensor<
@@ -544,7 +544,7 @@ using YoungTableauIndex = sil::tensor::TensorYoungTableauIndex<
 
 TEST(Tensor, YoungTableauIndexing)
 {
-    sil::tensor::TensorAccessor<Alpha, Beta, Gamma> natural_accessor;
+    [[maybe_unused]] sil::tensor::TensorAccessor<Alpha, Beta, Gamma> natural_accessor;
     ddc::DiscreteDomain<Alpha, Beta, Gamma> natural_dom = natural_accessor.mem_domain();
     ddc::Chunk natural_alloc(natural_dom, ddc::HostAllocator<double>());
     sil::tensor::Tensor<
@@ -582,7 +582,7 @@ TEST(Tensor, YoungTableauIndexing)
     natural(natural_accessor.access_element<Z, Z, Y>()) = 8.;
     natural(natural_accessor.access_element<Z, Z, Z>()) = 9.;
 
-    sil::tensor::TensorAccessor<YoungTableauIndex> tensor_accessor;
+    [[maybe_unused]] sil::tensor::TensorAccessor<YoungTableauIndex> tensor_accessor;
     ddc::DiscreteDomain<YoungTableauIndex> tensor_dom = tensor_accessor.mem_domain();
     ddc::Chunk tensor_alloc(tensor_dom, ddc::HostAllocator<double>());
     sil::tensor::Tensor<
@@ -664,7 +664,7 @@ TEST(Tensor, YoungTableauIndexing)
 
 TEST(Tensor, Determinant)
 {
-    sil::tensor::TensorAccessor<SymIndex> tensor_accessor;
+    [[maybe_unused]] sil::tensor::TensorAccessor<SymIndex> tensor_accessor;
     ddc::DiscreteDomain<SymIndex> tensor_dom = tensor_accessor.mem_domain();
     ddc::Chunk tensor_alloc(tensor_dom, ddc::HostAllocator<double>());
     sil::tensor::Tensor<

--- a/tests/tensor/tensor_prod.cpp
+++ b/tests/tensor/tensor_prod.cpp
@@ -43,7 +43,7 @@ struct Delta : sil::tensor::TensorNaturalIndex<X, Y, Z>
 
 TEST(TensorProd, SimpleContractionRank3xRank2)
 {
-    sil::tensor::TensorAccessor<Alpha, Beta, Gamma> tensor_accessor1;
+    [[maybe_unused]] sil::tensor::TensorAccessor<Alpha, Beta, Gamma> tensor_accessor1;
     ddc::DiscreteDomain<Alpha, Beta, Gamma> tensor1_dom = tensor_accessor1.mem_domain();
     ddc::Chunk tensor1_alloc(tensor1_dom, ddc::HostAllocator<double>());
     sil::tensor::Tensor<
@@ -82,7 +82,7 @@ TEST(TensorProd, SimpleContractionRank3xRank2)
     tensor1(tensor1.access_element<Z, Z, Z>()) = 26.;
 
 
-    sil::tensor::TensorAccessor<Gamma, Delta> tensor_accessor2;
+    [[maybe_unused]] sil::tensor::TensorAccessor<Gamma, Delta> tensor_accessor2;
     ddc::DiscreteDomain<Gamma, Delta> tensor2_dom = tensor_accessor2.mem_domain();
     ddc::Chunk tensor2_alloc(tensor2_dom, ddc::HostAllocator<double>());
     sil::tensor::Tensor<
@@ -102,7 +102,7 @@ TEST(TensorProd, SimpleContractionRank3xRank2)
     tensor2(tensor2.access_element<Z, Y>()) = 7.;
     tensor2(tensor2.access_element<Z, Z>()) = 8.;
 
-    sil::tensor::TensorAccessor<Alpha, Beta, Delta> prod_tensor_accessor;
+    [[maybe_unused]] sil::tensor::TensorAccessor<Alpha, Beta, Delta> prod_tensor_accessor;
     ddc::DiscreteDomain<Alpha, Beta, Delta> prod_tensor_dom = prod_tensor_accessor.mem_domain();
 
     ddc::Chunk prod_tensor_alloc(prod_tensor_dom, ddc::HostAllocator<double>());
@@ -146,7 +146,7 @@ TEST(TensorProd, SimpleContractionRank3xRank2)
 
 TEST(TensorProd, DoubleContractionRank3xRank3)
 {
-    sil::tensor::TensorAccessor<Alpha, Beta, Gamma> tensor_accessor1;
+    [[maybe_unused]] sil::tensor::TensorAccessor<Alpha, Beta, Gamma> tensor_accessor1;
     ddc::DiscreteDomain<Alpha, Beta, Gamma> tensor1_dom = tensor_accessor1.mem_domain();
     ddc::Chunk tensor1_alloc(tensor1_dom, ddc::HostAllocator<double>());
     sil::tensor::Tensor<
@@ -185,7 +185,7 @@ TEST(TensorProd, DoubleContractionRank3xRank3)
     tensor1(tensor1.access_element<Z, Z, Z>()) = 26.;
 
 
-    sil::tensor::TensorAccessor<Beta, Gamma, Delta> tensor_accessor2;
+    [[maybe_unused]] sil::tensor::TensorAccessor<Beta, Gamma, Delta> tensor_accessor2;
     ddc::DiscreteDomain<Beta, Gamma, Delta> tensor2_dom = tensor_accessor2.mem_domain();
     ddc::Chunk tensor2_alloc(tensor2_dom, ddc::HostAllocator<double>());
     sil::tensor::Tensor<
@@ -223,7 +223,7 @@ TEST(TensorProd, DoubleContractionRank3xRank3)
     tensor2(tensor2.access_element<Z, Z, Y>()) = 25.;
     tensor2(tensor2.access_element<Z, Z, Z>()) = 26.;
 
-    sil::tensor::TensorAccessor<Alpha, Delta> prod_tensor_accessor;
+    [[maybe_unused]] sil::tensor::TensorAccessor<Alpha, Delta> prod_tensor_accessor;
     ddc::DiscreteDomain<Alpha, Delta> prod_tensor_dom = prod_tensor_accessor.mem_domain();
 
     ddc::Chunk prod_tensor_alloc(prod_tensor_dom, ddc::HostAllocator<double>());
@@ -274,7 +274,7 @@ using Rank2SymIndex3 = sil::tensor::TensorSymmetricIndex<
 
 TEST(TensorProd, SimpleContractionRank2SymIndexedxRank2SymIndexed)
 {
-    sil::tensor::TensorAccessor<Rank2SymIndex1> tensor_accessor1;
+    [[maybe_unused]] sil::tensor::TensorAccessor<Rank2SymIndex1> tensor_accessor1;
     ddc::DiscreteDomain<Rank2SymIndex1> tensor1_dom = tensor_accessor1.mem_domain();
     ddc::Chunk tensor1_alloc(tensor1_dom, ddc::HostAllocator<double>());
     sil::tensor::Tensor<
@@ -296,7 +296,7 @@ TEST(TensorProd, SimpleContractionRank2SymIndexedxRank2SymIndexed)
     tensor1(tensor1.access_element<Z, Z>()) = 10.;
 
 
-    sil::tensor::TensorAccessor<Rank2SymIndex2> tensor_accessor2;
+    [[maybe_unused]] sil::tensor::TensorAccessor<Rank2SymIndex2> tensor_accessor2;
     ddc::DiscreteDomain<Rank2SymIndex2> tensor2_dom = tensor_accessor2.mem_domain();
     ddc::Chunk tensor2_alloc(tensor2_dom, ddc::HostAllocator<double>());
     sil::tensor::Tensor<
@@ -318,7 +318,7 @@ TEST(TensorProd, SimpleContractionRank2SymIndexedxRank2SymIndexed)
     tensor2(tensor2.access_element<Z, Z>()) = 20.;
 
 
-    sil::tensor::TensorAccessor<Rank2SymIndex3> prod_tensor_accessor;
+    [[maybe_unused]] sil::tensor::TensorAccessor<Rank2SymIndex3> prod_tensor_accessor;
     ddc::DiscreteDomain<Rank2SymIndex3> prod_tensor_dom = prod_tensor_accessor.mem_domain();
 
     ddc::Chunk prod_tensor_alloc(prod_tensor_dom, ddc::HostAllocator<double>());
@@ -355,7 +355,7 @@ using Rank2AntisymIndex3 = sil::tensor::TensorAntisymmetricIndex<
 
 TEST(TensorProd, SimpleContractionRank2AntisymIndexedxRank2AntisymIndexed)
 {
-    sil::tensor::TensorAccessor<Rank2AntisymIndex1> tensor_accessor1;
+    [[maybe_unused]] sil::tensor::TensorAccessor<Rank2AntisymIndex1> tensor_accessor1;
     ddc::DiscreteDomain<Rank2AntisymIndex1> tensor1_dom = tensor_accessor1.mem_domain();
     ddc::Chunk tensor1_alloc(tensor1_dom, ddc::HostAllocator<double>());
     sil::tensor::Tensor<
@@ -373,7 +373,7 @@ TEST(TensorProd, SimpleContractionRank2AntisymIndexedxRank2AntisymIndexed)
     tensor1(tensor1.access_element<Y, Z>()) = 6.;
 
 
-    sil::tensor::TensorAccessor<Rank2AntisymIndex2> tensor_accessor2;
+    [[maybe_unused]] sil::tensor::TensorAccessor<Rank2AntisymIndex2> tensor_accessor2;
     ddc::DiscreteDomain<Rank2AntisymIndex2> tensor2_dom = tensor_accessor2.mem_domain();
     ddc::Chunk tensor2_alloc(tensor2_dom, ddc::HostAllocator<double>());
     sil::tensor::Tensor<
@@ -391,7 +391,7 @@ TEST(TensorProd, SimpleContractionRank2AntisymIndexedxRank2AntisymIndexed)
     tensor2(tensor2.access_element<Y, Z>()) = 12.;
 
 
-    sil::tensor::TensorAccessor<Rank2AntisymIndex3> prod_tensor_accessor;
+    [[maybe_unused]] sil::tensor::TensorAccessor<Rank2AntisymIndex3> prod_tensor_accessor;
     ddc::DiscreteDomain<Rank2AntisymIndex3> prod_tensor_dom = prod_tensor_accessor.mem_domain();
 
     ddc::Chunk prod_tensor_alloc(prod_tensor_dom, ddc::HostAllocator<double>());
@@ -430,7 +430,7 @@ using Rank3SymIndex3 = sil::tensor::TensorSymmetricIndex<
 
 TEST(TensorProd, SimpleContractionRank3SymIndexedxRank2SymIndexed)
 {
-    sil::tensor::TensorAccessor<Rank3SymIndex1> tensor_accessor1;
+    [[maybe_unused]] sil::tensor::TensorAccessor<Rank3SymIndex1> tensor_accessor1;
     ddc::DiscreteDomain<Rank3SymIndex1> tensor1_dom = tensor_accessor1.mem_domain();
     ddc::Chunk tensor1_alloc(tensor1_dom, ddc::HostAllocator<double>());
     sil::tensor::Tensor<
@@ -462,7 +462,7 @@ TEST(TensorProd, SimpleContractionRank3SymIndexedxRank2SymIndexed)
     tensor1(tensor1.access_element<Z, Z, Z>()) = 20.;
 
 
-    sil::tensor::TensorAccessor<Rank3SymIndex2> tensor_accessor2;
+    [[maybe_unused]] sil::tensor::TensorAccessor<Rank3SymIndex2> tensor_accessor2;
     ddc::DiscreteDomain<Rank3SymIndex2> tensor2_dom = tensor_accessor2.mem_domain();
     ddc::Chunk tensor2_alloc(tensor2_dom, ddc::HostAllocator<double>());
     sil::tensor::Tensor<
@@ -484,7 +484,7 @@ TEST(TensorProd, SimpleContractionRank3SymIndexedxRank2SymIndexed)
     tensor2(tensor2.access_element<Z, Z>()) = 30.;
 
 
-    sil::tensor::TensorAccessor<Rank3SymIndex3> prod_tensor_accessor;
+    [[maybe_unused]] sil::tensor::TensorAccessor<Rank3SymIndex3> prod_tensor_accessor;
     ddc::DiscreteDomain<Rank3SymIndex3> prod_tensor_dom = prod_tensor_accessor.mem_domain();
 
     ddc::Chunk prod_tensor_alloc(prod_tensor_dom, ddc::HostAllocator<double>());
@@ -533,7 +533,7 @@ using Rank3AntisymIndex3 = sil::tensor::TensorAntisymmetricIndex<
 
 TEST(TensorProd, SimpleContractionRank3AntisymIndexedxRank2AntisymIndexed)
 {
-    sil::tensor::TensorAccessor<Rank3AntisymIndex1> tensor_accessor1;
+    [[maybe_unused]] sil::tensor::TensorAccessor<Rank3AntisymIndex1> tensor_accessor1;
     ddc::DiscreteDomain<Rank3AntisymIndex1> tensor1_dom = tensor_accessor1.mem_domain();
     ddc::Chunk tensor1_alloc(tensor1_dom, ddc::HostAllocator<double>());
     sil::tensor::Tensor<
@@ -549,7 +549,7 @@ TEST(TensorProd, SimpleContractionRank3AntisymIndexedxRank2AntisymIndexed)
     tensor1(tensor1.access_element<X, Y, Z>()) = 4.;
 
 
-    sil::tensor::TensorAccessor<Rank3AntisymIndex2> tensor_accessor2;
+    [[maybe_unused]] sil::tensor::TensorAccessor<Rank3AntisymIndex2> tensor_accessor2;
     ddc::DiscreteDomain<Rank3AntisymIndex2> tensor2_dom = tensor_accessor2.mem_domain();
     ddc::Chunk tensor2_alloc(tensor2_dom, ddc::HostAllocator<double>());
     sil::tensor::Tensor<
@@ -567,7 +567,7 @@ TEST(TensorProd, SimpleContractionRank3AntisymIndexedxRank2AntisymIndexed)
     tensor2(tensor2.access_element<Y, Z>()) = 10.;
 
 
-    sil::tensor::TensorAccessor<Rank3AntisymIndex3> prod_tensor_accessor;
+    [[maybe_unused]] sil::tensor::TensorAccessor<Rank3AntisymIndex3> prod_tensor_accessor;
     ddc::DiscreteDomain<Rank3AntisymIndex3> prod_tensor_dom = prod_tensor_accessor.mem_domain();
 
     ddc::Chunk prod_tensor_alloc(prod_tensor_dom, ddc::HostAllocator<double>());
@@ -596,7 +596,7 @@ using YoungTableauIndex = sil::tensor::TensorYoungTableauIndex<
 
 TEST(TensorProd, DoubleContractionYoungIndexedxNaturalIndex)
 {
-    sil::tensor::TensorAccessor<Alpha, Beta, Gamma> natural_accessor;
+    [[maybe_unused]] sil::tensor::TensorAccessor<Alpha, Beta, Gamma> natural_accessor;
     ddc::DiscreteDomain<Alpha, Beta, Gamma> natural_dom = natural_accessor.mem_domain();
     ddc::Chunk natural_alloc(natural_dom, ddc::HostAllocator<double>());
     sil::tensor::Tensor<
@@ -634,7 +634,7 @@ TEST(TensorProd, DoubleContractionYoungIndexedxNaturalIndex)
     natural(natural_accessor.access_element<Z, Z, Y>()) = 8.;
     natural(natural_accessor.access_element<Z, Z, Z>()) = 9.;
 
-    sil::tensor::TensorAccessor<YoungTableauIndex> tensor_accessor1;
+    [[maybe_unused]] sil::tensor::TensorAccessor<YoungTableauIndex> tensor_accessor1;
     ddc::DiscreteDomain<YoungTableauIndex> tensor1_dom = tensor_accessor1.mem_domain();
     ddc::Chunk tensor1_alloc(tensor1_dom, ddc::HostAllocator<double>());
     sil::tensor::Tensor<
@@ -646,7 +646,7 @@ TEST(TensorProd, DoubleContractionYoungIndexedxNaturalIndex)
 
     sil::tensor::compress(tensor1, natural);
 
-    sil::tensor::TensorAccessor<Beta, Gamma, Delta> tensor_accessor2;
+    [[maybe_unused]] sil::tensor::TensorAccessor<Beta, Gamma, Delta> tensor_accessor2;
     ddc::DiscreteDomain<Beta, Gamma, Delta> tensor2_dom = tensor_accessor2.mem_domain();
     ddc::Chunk tensor2_alloc(tensor2_dom, ddc::HostAllocator<double>());
     sil::tensor::Tensor<
@@ -684,7 +684,7 @@ TEST(TensorProd, DoubleContractionYoungIndexedxNaturalIndex)
     tensor2(tensor2.access_element<Z, Z, Y>()) = 25.;
     tensor2(tensor2.access_element<Z, Z, Z>()) = 26.;
 
-    sil::tensor::TensorAccessor<Alpha, Delta> prod_tensor_accessor;
+    [[maybe_unused]] sil::tensor::TensorAccessor<Alpha, Delta> prod_tensor_accessor;
     ddc::DiscreteDomain<Alpha, Delta> prod_tensor_dom = prod_tensor_accessor.mem_domain();
 
     ddc::Chunk prod_tensor_alloc(prod_tensor_dom, ddc::HostAllocator<double>());

--- a/tests/young_tableau/young_tableau.cpp
+++ b/tests/young_tableau/young_tableau.cpp
@@ -56,7 +56,7 @@ TEST(YoungTableau, 1_2)
 
     EXPECT_EQ(young_tableau.irrep_dim(), 10);
 
-    sil::tensor::TensorAccessor<Mu, Nu> tensor_accessor;
+    [[maybe_unused]] sil::tensor::TensorAccessor<Mu, Nu> tensor_accessor;
     ddc::DiscreteDomain<Mu, Nu> tensor_dom = tensor_accessor.mem_domain();
     ddc::Chunk tensor_alloc(tensor_dom, ddc::HostAllocator<double>());
     sil::tensor::Tensor<
@@ -132,7 +132,7 @@ TEST(YoungTableau, 1l2)
 
     EXPECT_EQ(young_tableau.irrep_dim(), 6);
 
-    sil::tensor::TensorAccessor<Mu, Nu> tensor_accessor;
+    [[maybe_unused]] sil::tensor::TensorAccessor<Mu, Nu> tensor_accessor;
     ddc::DiscreteDomain<Mu, Nu> tensor_dom = tensor_accessor.mem_domain();
     ddc::Chunk tensor_alloc(tensor_dom, ddc::HostAllocator<double>());
     sil::tensor::Tensor<
@@ -211,7 +211,7 @@ TEST(YoungTableau, 1_2_3)
 
     EXPECT_EQ(young_tableau.irrep_dim(), 10);
 
-    sil::tensor::TensorAccessor<Alpha, Beta, Gamma> tensor_accessor;
+    [[maybe_unused]] sil::tensor::TensorAccessor<Alpha, Beta, Gamma> tensor_accessor;
     ddc::DiscreteDomain<Alpha, Beta, Gamma> tensor_dom = tensor_accessor.mem_domain();
     ddc::Chunk tensor_alloc(tensor_dom, ddc::HostAllocator<double>());
     sil::tensor::Tensor<
@@ -330,7 +330,7 @@ TEST(YoungTableau, 1l2l3)
                     std::index_sequence<3>>>
             young_tableau;
 
-    sil::tensor::TensorAccessor<Alpha, Beta, Gamma> tensor_accessor;
+    [[maybe_unused]] sil::tensor::TensorAccessor<Alpha, Beta, Gamma> tensor_accessor;
     ddc::DiscreteDomain<Alpha, Beta, Gamma> tensor_dom = tensor_accessor.mem_domain();
     ddc::Chunk tensor_alloc(tensor_dom, ddc::HostAllocator<double>());
     sil::tensor::Tensor<
@@ -451,7 +451,7 @@ TEST(YoungTableau, 1_2l3)
 
     EXPECT_EQ(young_tableau.irrep_dim(), 8);
 
-    sil::tensor::TensorAccessor<Alpha, Beta, Gamma> tensor_accessor;
+    [[maybe_unused]] sil::tensor::TensorAccessor<Alpha, Beta, Gamma> tensor_accessor;
     ddc::DiscreteDomain<Alpha, Beta, Gamma> tensor_dom = tensor_accessor.mem_domain();
     ddc::Chunk tensor_alloc(tensor_dom, ddc::HostAllocator<double>());
     sil::tensor::Tensor<
@@ -525,7 +525,7 @@ TEST(YoungTableau, 1_3l2)
 
     EXPECT_EQ(young_tableau.irrep_dim(), 8);
 
-    sil::tensor::TensorAccessor<Alpha, Beta, Gamma> tensor_accessor;
+    [[maybe_unused]] sil::tensor::TensorAccessor<Alpha, Beta, Gamma> tensor_accessor;
     ddc::DiscreteDomain<Alpha, Beta, Gamma> tensor_dom = tensor_accessor.mem_domain();
     ddc::Chunk tensor_alloc(tensor_dom, ddc::HostAllocator<double>());
     sil::tensor::Tensor<
@@ -600,7 +600,7 @@ TEST(YoungTableau, 1l3_2l4)
 
     EXPECT_EQ(young_tableau.irrep_dim(), 6);
 
-    sil::tensor::TensorAccessor<Alpha, Beta, Gamma, Delta> tensor_accessor;
+    [[maybe_unused]] sil::tensor::TensorAccessor<Alpha, Beta, Gamma, Delta> tensor_accessor;
     ddc::DiscreteDomain<Alpha, Beta, Gamma, Delta> tensor_dom = tensor_accessor.mem_domain();
     ddc::Chunk tensor_alloc(tensor_dom, ddc::HostAllocator<double>());
     sil::tensor::Tensor<


### PR DESCRIPTION
Most of the time, we build tensor accessors only to call one of it's static member functions, which triggers the "is unused" warning in nvcc. So we decorate them with attribute `[[maybe_unused]]`.