### PR TITLE
Improve scheduling

### DIFF
--- a/.devnote
+++ b/.devnote
@@ -18,6 +18,8 @@ SPDX-License-Identifier: GPL-3.0-or-later
 - Consider removing metric_prod_t (and every helper producing a tensor). At least, standardize API.
 - Relabelizion in different file ?
 - Streams in Laplacian
+- Clarify domain() and mem_domain() (the same)
+- There are several projection of metric on MetricIndex which is simply a metric.indices_domain()
 
 ----- SETUP BASIC COMMAND -----
 

--- a/.devnote
+++ b/.devnote
@@ -20,6 +20,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
 - Streams in Laplacian
 - Clarify domain() and mem_domain() (the same)
 - There are several projection of metric on MetricIndex which is simply a metric.indices_domain()
+- swap_character_t
 
 ----- SETUP BASIC COMMAND -----
 

--- a/include/similie/exterior/coboundary.hpp
+++ b/include/similie/exterior/coboundary.hpp
@@ -253,16 +253,14 @@ coboundary_tensor_t<TagToAddToCochain, CochainTag, TensorType> coboundary(
             CochainTag::rank() + 1,
             typename detail::NonSpectatorDimension<
                     TagToAddToCochain,
-                    typename TensorType::non_indices_domain_t>::type,
-            typename ExecSpace::memory_space>();
+                    typename TensorType::non_indices_domain_t>::type>(exec_space);
 
     // compute the tangent K-basis for each node of the mesh. This is a local K-chain.
     auto lower_chain = tangent_basis<
             CochainTag::rank(),
             typename detail::NonSpectatorDimension<
                     TagToAddToCochain,
-                    typename TensorType::non_indices_domain_t>::type,
-            typename ExecSpace::memory_space>();
+                    typename TensorType::non_indices_domain_t>::type>(exec_space);
 
     // iterate over every node, we will work inside the tangent space associated to each of them
     ddc::parallel_for_each(

--- a/include/similie/exterior/codifferential.hpp
+++ b/include/similie/exterior/codifferential.hpp
@@ -197,7 +197,6 @@ codifferential_tensor_t<TagToRemoveFromCochain, CochainTag, TensorType> codiffer
             sil::tensor::upper<MetricIndex>,
             MuUpSeq,
             NuLowSeq>(exec_space, hodge_star, inv_metric);
-    exec_space.fence();
 
     // Dual tensor
     [[maybe_unused]] tensor::TensorAccessor<
@@ -219,7 +218,6 @@ codifferential_tensor_t<TagToRemoveFromCochain, CochainTag, TensorType> codiffer
             KOKKOS_LAMBDA(typename TensorType::non_indices_domain_t::discrete_element_type elem) {
                 sil::tensor::tensor_prod(dual_tensor[elem], tensor[elem], hodge_star[elem]);
             });
-    exec_space.fence();
 
     // Dual codifferential
     [[maybe_unused]] tensor::TensorAccessor<
@@ -241,7 +239,6 @@ codifferential_tensor_t<TagToRemoveFromCochain, CochainTag, TensorType> codiffer
             misc::convert_type_seq_to_t<
                     tensor::TensorAntisymmetricIndex,
                     NuLowSeq>>(exec_space, dual_codifferential, dual_tensor);
-    exec_space.fence();
 
     // Hodge star 2
     [[maybe_unused]] sil::tensor::tensor_accessor_for_domain_t<HodgeStarDomain2>
@@ -257,7 +254,6 @@ codifferential_tensor_t<TagToRemoveFromCochain, CochainTag, TensorType> codiffer
             sil::tensor::upper<MetricIndex>,
             RhoUpSeq,
             SigmaLowSeq>(exec_space, hodge_star2, inv_metric);
-    exec_space.fence();
 
     // Codifferential
     ddc::parallel_for_each(
@@ -273,7 +269,6 @@ codifferential_tensor_t<TagToRemoveFromCochain, CochainTag, TensorType> codiffer
                     codifferential_tensor[elem] *= -1;
                 }
             });
-    exec_space.fence();
 
     return codifferential_tensor;
 }

--- a/include/similie/exterior/laplacian.hpp
+++ b/include/similie/exterior/laplacian.hpp
@@ -45,7 +45,6 @@ TensorType codifferential_of_coboundary(
     sil::tensor::Tensor derivative_tensor(derivative_tensor_alloc);
 
     sil::exterior::deriv<LaplacianDummyIndex, CochainTag>(exec_space, derivative_tensor, tensor);
-    exec_space.fence();
 
     // Codifferential
     sil::exterior::codifferential<
@@ -54,7 +53,6 @@ TensorType codifferential_of_coboundary(
             coboundary_index_t<
                     LaplacianDummyIndex,
                     CochainTag>>(exec_space, out_tensor, derivative_tensor, inv_metric);
-    exec_space.fence();
 
     return out_tensor;
 }
@@ -90,7 +88,6 @@ TensorType coboundary_of_codifferential(
             MetricIndex,
             LaplacianDummyIndex,
             CochainTag>(exec_space, codifferential_tensor, tensor, inv_metric);
-    exec_space.fence();
 
     // Coboundary
     sil::exterior::deriv<
@@ -98,7 +95,6 @@ TensorType coboundary_of_codifferential(
             codifferential_index_t<
                     LaplacianDummyIndex,
                     CochainTag>>(exec_space, out_tensor, codifferential_tensor);
-    exec_space.fence();
 
     return out_tensor;
 }
@@ -132,7 +128,6 @@ TensorType laplacian(
                 MetricIndex,
                 LaplacianDummyIndex2,
                 CochainTag>(exec_space, laplacian_tensor, tensor, inv_metric);
-        exec_space.fence();
     } else if constexpr (CochainTag::rank() < LaplacianDummyIndex::size()) {
         auto tmp_alloc = ddc::create_mirror(exec_space, laplacian_tensor);
         tensor::Tensor tmp(tmp_alloc);
@@ -145,7 +140,6 @@ TensorType laplacian(
                 MetricIndex,
                 LaplacianDummyIndex,
                 CochainTag>(exec_space, tmp, tensor, inv_metric);
-        exec_space.fence();
 
         ddc::parallel_for_each(
                 exec_space,
@@ -158,7 +152,6 @@ TensorType laplacian(
                 MetricIndex,
                 LaplacianDummyIndex,
                 CochainTag>(exec_space, laplacian_tensor, tensor, inv_metric);
-        exec_space.fence();
     } else {
         assert(false && "Unsupported differential form in Laplacian operator");
     }

--- a/include/similie/exterior/laplacian.hpp
+++ b/include/similie/exterior/laplacian.hpp
@@ -134,7 +134,7 @@ TensorType laplacian(
                 CochainTag>(exec_space, laplacian_tensor, tensor, inv_metric);
         exec_space.fence();
     } else if constexpr (CochainTag::rank() < LaplacianDummyIndex::size()) {
-        auto tmp_alloc = ddc::create_mirror(laplacian_tensor);
+        auto tmp_alloc = ddc::create_mirror(exec_space, laplacian_tensor);
         tensor::Tensor tmp(tmp_alloc);
 
         detail::codifferential_of_coboundary<

--- a/include/similie/tensor/determinant.hpp
+++ b/include/similie/tensor/determinant.hpp
@@ -68,6 +68,7 @@ KOKKOS_FUNCTION typename ViewType::value_type determinant(const ViewType& matrix
     return det;
 }
 
+// TODO port on GPU
 template <misc::Specialization<Tensor> TensorType>
 TensorType::element_type determinant(TensorType tensor)
 {

--- a/include/similie/tensor/identity_tensor.hpp
+++ b/include/similie/tensor/identity_tensor.hpp
@@ -88,8 +88,11 @@ struct TensorIdentityIndex
     KOKKOS_FUNCTION static constexpr std::array<std::size_t, rank()>
     mem_id_to_canonical_natural_ids(std::size_t mem_id)
     {
-        assert(mem_id < mem_size()); // Always false
+        assert(false);
         std::array<std::size_t, rank()> ids;
+        for (auto i = ids.begin(); i < ids.end(); ++i) {
+            *i = 0;
+        }
         return ids;
     }
 };

--- a/include/similie/tensor/levi_civita_tensor.hpp
+++ b/include/similie/tensor/levi_civita_tensor.hpp
@@ -99,8 +99,11 @@ struct TensorLeviCivitaIndex
     KOKKOS_FUNCTION static constexpr std::array<std::size_t, rank()>
     mem_id_to_canonical_natural_ids(std::size_t mem_id)
     {
-        assert(mem_id < mem_size()); // Always false
+        assert(false);
         std::array<std::size_t, rank()> ids;
+        for (auto i = ids.begin(); i < ids.end(); ++i) {
+            *i = 0;
+        }
         return ids;
     }
 };

--- a/include/similie/tensor/lorentzian_sign_tensor.hpp
+++ b/include/similie/tensor/lorentzian_sign_tensor.hpp
@@ -94,8 +94,11 @@ struct TensorLorentzianSignIndex
     KOKKOS_FUNCTION static constexpr std::array<std::size_t, rank()>
     mem_id_to_canonical_natural_ids(std::size_t mem_id)
     {
-        assert(mem_id < mem_size()); // Always false
+        assert(false);
         std::array<std::size_t, rank()> ids;
+        for (auto i = ids.begin(); i < ids.end(); ++i) {
+            *i = 0;
+        }
         return ids;
     }
 };

--- a/include/similie/tensor/metric.hpp
+++ b/include/similie/tensor/metric.hpp
@@ -350,6 +350,7 @@ inplace_apply_metric(ExecSpace const& exec_space, TensorType tensor, MetricType 
                                 tensor)[elem]);
             });
     Kokkos::deep_copy(
+            exec_space,
             tensor.allocation_kokkos_view(),
             result.allocation_kokkos_view()); // We rely on Kokkos::deep_copy in place of ddc::parallel_deepcopy to avoid type verification of the type dimensions
 
@@ -416,14 +417,14 @@ invert_metric_t<MetricType> fill_inverse_metric(
                 exec_space,
                 inv_metric.mem_domain(),
                 KOKKOS_LAMBDA(invert_metric_t<MetricType>::discrete_element_type elem) {
-                    inv_metric(elem)
+                    inv_metric.mem(elem)
                             = 1.
-                              / metric(relabelize_indices_in<
-                                       swap_character<ddc::to_type_seq_t<
-                                               typename MetricType::accessor_t::natural_domain_t>>,
-                                       ddc::to_type_seq_t<
-                                               typename MetricType::accessor_t::natural_domain_t>>(
-                                      elem));
+                              / metric.mem(relabelize_indices_in<
+                                           swap_character<ddc::to_type_seq_t<
+                                                   typename MetricType::accessor_t::
+                                                           natural_domain_t>>,
+                                           ddc::to_type_seq_t<typename MetricType::accessor_t::
+                                                                      natural_domain_t>>(elem));
                 });
     } else if (misc::Specialization<MetricIndex, TensorSymmetricIndex>) {
         // Allocate a buffer mirroring the metric as a full matrix
@@ -502,16 +503,11 @@ invert_metric_t<MetricType> fill_inverse_metric(
                     */
 
                     ddc::for_each(
-                            tensor::swap_character<ddc::DiscreteDomain<
-                                    tensor::metric_index_1<MetricIndex>,
-                                    tensor::metric_index_2<MetricIndex>>>(
-                                    inv_metric.natural_domain()),
-                            [=](decltype(tensor::swap_character<ddc::DiscreteDomain<
-                                                 tensor::metric_index_1<MetricIndex>,
-                                                 tensor::metric_index_2<MetricIndex>>>(
-                                    inv_metric.natural_domain()))::discrete_element_type index) {
-                                // TODO do better, symmetric tensor is filled twice
-                                inv_metric(inv_metric.access_element(elem, index)) = buffer(
+                            tensor::swap_character<ddc::DiscreteDomain<MetricIndex>>(
+                                    inv_metric.domain()),
+                            [=](decltype(tensor::swap_character<ddc::DiscreteDomain<MetricIndex>>(
+                                    inv_metric.domain()))::discrete_element_type mem_index) {
+                                inv_metric.mem(elem, mem_index) = buffer(
                                         elem,
                                         tensor::relabelize_indices_in<
                                                 tensor::swap_character<ddc::detail::TypeSeq<
@@ -520,7 +516,8 @@ invert_metric_t<MetricType> fill_inverse_metric(
                                                 ddc::detail::TypeSeq<
                                                         tensor::metric_index_1<MetricIndex>,
                                                         tensor::metric_index_2<MetricIndex>>>(
-                                                index));
+                                                inv_metric.accessor().canonical_natural_element(
+                                                        mem_index)));
                             });
                 });
     }

--- a/include/similie/tensor/tensor_impl.hpp
+++ b/include/similie/tensor/tensor_impl.hpp
@@ -1204,7 +1204,7 @@ struct NaturalTensorProd<
     run(Tensor<ElementType,
                ddc::DiscreteDomain<HeadDDim1..., TailDDim2...>,
                LayoutStridedPolicy,
-               Kokkos::DefaultHostExecutionSpace::memory_space> prod_tensor,
+               MemorySpace> prod_tensor,
         Tensor<ElementType,
                ddc::DiscreteDomain<HeadDDim1..., ContractDDim...>,
                LayoutStridedPolicy,
@@ -1239,15 +1239,9 @@ template <
         class ElementType,
         class LayoutStridedPolicy,
         class MemorySpace>
-Tensor<ElementType,
-       ddc::DiscreteDomain<ProdDDim...>,
-       LayoutStridedPolicy,
-       Kokkos::DefaultHostExecutionSpace::memory_space>
-tensor_prod(
-        Tensor<ElementType,
-               ddc::DiscreteDomain<ProdDDim...>,
-               LayoutStridedPolicy,
-               Kokkos::DefaultHostExecutionSpace::memory_space> prod_tensor,
+Tensor<ElementType, ddc::DiscreteDomain<ProdDDim...>, LayoutStridedPolicy, MemorySpace> tensor_prod(
+        Tensor<ElementType, ddc::DiscreteDomain<ProdDDim...>, LayoutStridedPolicy, MemorySpace>
+                prod_tensor,
         Tensor<ElementType, ddc::DiscreteDomain<DDim1...>, LayoutStridedPolicy, MemorySpace>
                 tensor1,
         Tensor<ElementType, ddc::DiscreteDomain<DDim2...>, LayoutStridedPolicy, MemorySpace>


### PR DESCRIPTION
- `tangent_basis` takes ExecutionSpace instance as argument.
- Remove unecessary fences
- Ensure synchronous deep_copies
- Fixes
- Use DDC fork